### PR TITLE
fix: Windows 환경에서 uvloop 설치 오류 대응

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,6 +44,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3
 uvicorn==0.42.0
-uvloop==0.22.1
+# Windows에서는 uvloop 미지원 → 조건부 설치
+uvloop==0.22.1; platform_system != "Windows"
 watchfiles==1.1.1
 websockets==16.0


### PR DESCRIPTION
## 연관 이슈
#21 

## 작업 내용
- requirements.txt의 uvloop를 Windows 제외 조건부 설치로 수정
- Windows 로컬 환경에서 패키지 설치 오류가 발생하지 않도록 대응

## 테스트
- Windows 환경에서 pip install -r requirements.txt 실행
- uvloop 관련 오류 없이 정상 설치 확인

## 스크린샷

<img width="941" height="86" alt="uvloopGood" src="https://github.com/user-attachments/assets/c4743b04-8ade-424b-83d0-e6b873860e2f" />

## 참고
- 본 수정은 로컬 Windows 개발 환경 대응 목적의 임시 조치
