### PR TITLE
feat: 프로젝트 목록 mock API 연동

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,5 +1,6 @@
 import axios from "axios"
 
+// 세션 쿠키를 포함한 공통 API 요청을 처리하는 axios 인스턴스
 export const api = axios.create({
   baseURL: "/",
   withCredentials: true,

--- a/frontend/src/api/projectApi.js
+++ b/frontend/src/api/projectApi.js
@@ -1,0 +1,7 @@
+import { api } from "./client"
+
+// 프로젝트 목록을 조회하는 API 함수
+export async function getProjects() {
+  const response = await api.get("/projects")
+  return response.data
+}

--- a/frontend/src/hooks/useProjects.js
+++ b/frontend/src/hooks/useProjects.js
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query"
+import { getProjects } from "@/api/projectApi"
+
+// 프로젝트 목록 조회를 TanStack Query로 관리하는 커스텀 훅
+export function useProjects() {
+  return useQuery({
+    queryKey: ["projects"],
+    queryFn: getProjects,
+  })
+}

--- a/frontend/src/mocks/data/projects.js
+++ b/frontend/src/mocks/data/projects.js
@@ -1,0 +1,21 @@
+// 프로젝트 목록 조회 API에서 사용할 mock 프로젝트 데이터
+export const projects = [
+  {
+    id: 1,
+    name: "web_only",
+    description: "Nginx 단일 컨테이너로 구성된 프로젝트",
+    created_at: "2026-03-28T09:00:00.000Z",
+  },
+  {
+    id: 2,
+    name: "web_db",
+    description: "Nginx와 Postgres로 구성된 프로젝트",
+    created_at: "2026-03-27T09:00:00.000Z",
+  },
+  {
+    id: 3,
+    name: "web_db_cache",
+    description: null,
+    created_at: "2026-03-26T09:00:00.000Z",
+  },
+]

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -1,9 +1,18 @@
 import { http, HttpResponse } from "msw"
+import { projects } from "./data/projects"
 
 export const handlers = [
+  // MSW 동작 여부를 확인하기 위한 테스트용 엔드포인트
   http.get("/api/health", () => {
     return HttpResponse.json({
       message: "MSW is running",
+    })
+  }),
+
+  // 프로젝트 목록 조회 요청에 대해 mock 데이터를 반환
+  http.get("/projects", () => {
+    return HttpResponse.json({
+      projects,
     })
   }),
 ]

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,27 +1,11 @@
-import { useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { useProjects } from "@/hooks/useProjects"
 
-const mockProjects = [
-  {
-    id: "1",
-    name: "web_only",
-    description: "Nginx 단일 컨테이너로 구성된 프로젝트",
-  },
-  {
-    id: "2",
-    name: "web_db",
-    description: "Nginx와 Postgres로 구성된 프로젝트",
-  },
-  {
-    id: "3",
-    name: "web_db_cache",
-    description: "Nginx, Postgres, Redis로 구성된 프로젝트",
-  },
-]
-
+// 선택된 프로젝트에 따라 표시할 컨테이너 목록 mock 데이터
 const mockContainersByProject = {
-  "1": [
+  1: [
     {
       id: "1-1",
       name: "nginx",
@@ -29,7 +13,7 @@ const mockContainersByProject = {
       status: "running",
     },
   ],
-  "2": [
+  2: [
     {
       id: "2-1",
       name: "nginx",
@@ -43,7 +27,7 @@ const mockContainersByProject = {
       status: "stopped",
     },
   ],
-  "3": [
+  3: [
     {
       id: "3-1",
       name: "nginx",
@@ -65,20 +49,49 @@ const mockContainersByProject = {
   ],
 }
 
+// API에서 받은 created_at 값을 화면용 날짜 문자열로 변환
+function formatCreatedAt(createdAt) {
+  if (!createdAt) return "-"
+
+  const date = new Date(createdAt)
+
+  if (Number.isNaN(date.getTime())) {
+    return createdAt
+  }
+
+  return date.toLocaleDateString("ko-KR")
+}
+
 export default function Dashboard() {
-  const [selectedProjectId, setSelectedProjectId] = useState(mockProjects[0].id)
+  // 현재 선택된 프로젝트와 상세 탭 상태를 관리
+  const [selectedProjectId, setSelectedProjectId] = useState(null)
   const [activeTab, setActiveTab] = useState("metrics")
 
-  const selectedProject = mockProjects.find(
-    (project) => project.id === selectedProjectId
-  )
+  // 프로젝트 목록 조회 상태를 TanStack Query로 관리
+  const { data, isLoading, isError, error } = useProjects()
 
-  const containers = mockContainersByProject[selectedProjectId] || []
+  // API 응답에서 프로젝트 배열만 추출
+  const projects = data?.projects ?? []
+
+  // 프로젝트 목록이 로드되면 첫 프로젝트를 기본 선택
+  useEffect(() => {
+    if (projects.length > 0 && selectedProjectId === null) {
+      setSelectedProjectId(projects[0].id)
+    }
+  }, [projects, selectedProjectId])
+
+  // 선택된 프로젝트 id에 해당하는 프로젝트 정보를 계산
+  const selectedProject = useMemo(() => {
+    return projects.find((project) => project.id === selectedProjectId) ?? null
+  }, [projects, selectedProjectId])
+
+  // 선택된 프로젝트에 맞는 컨테이너 목록을 표시
+  const containers =
+    selectedProjectId !== null ? mockContainersByProject[selectedProjectId] || [] : []
 
   return (
     <div className="min-h-screen bg-slate-50 px-6 py-8">
       <div className="mx-auto max-w-6xl space-y-6">
-        {/* Dashboard 헤더 영역 */}
         <div>
           <h1 className="text-3xl font-bold">Dashboard</h1>
           <p className="mt-1 text-sm text-slate-600">
@@ -88,60 +101,85 @@ export default function Dashboard() {
         </div>
 
         <div className="grid gap-6 lg:grid-cols-12">
-          {/* 프로젝트 목록 영역 */}
           <section className="lg:col-span-4">
             <Card className="h-full">
               <CardHeader>
                 <CardTitle>프로젝트 목록</CardTitle>
               </CardHeader>
-              <CardContent className="space-y-3">
-                {/* 프로젝트 목록 UI */}
-                <div className="space-y-2">
-                  {mockProjects.map((project) => {
-                    const isSelected = selectedProjectId === project.id
 
-                    return (
-                      <button
-                        key={project.id}
-                        type="button"
-                        onClick={() => setSelectedProjectId(project.id)}
-                        className={`w-full rounded-lg border p-4 text-left transition ${
-                          isSelected
-                            ? "border-slate-900 bg-slate-100 ring-1 ring-slate-900"
-                            : "bg-white hover:border-slate-300 hover:bg-slate-50"
-                        }`}
-                      >
-                        <p className="font-medium text-slate-900">{project.name}</p>
-                        <p className="mt-1 text-sm text-slate-600">
-                          {project.description}
-                        </p>
-                      </button>
-                    )
-                  })}
-                </div>
+              <CardContent className="space-y-3">
+                {isLoading ? (
+                  <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-500">
+                    프로젝트 목록을 불러오는 중입니다.
+                  </div>
+                ) : isError ? (
+                  <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-600">
+                    {error?.message ?? "프로젝트 목록을 불러오지 못했습니다."}
+                  </div>
+                ) : projects.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-500">
+                    등록된 프로젝트가 없습니다.
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {projects.map((project) => {
+                      const isSelected = selectedProjectId === project.id
+
+                      return (
+                        <button
+                          key={project.id}
+                          type="button"
+                          onClick={() => setSelectedProjectId(project.id)}
+                          className={`w-full rounded-lg border p-4 text-left transition ${
+                            isSelected
+                              ? "border-slate-900 bg-slate-100 ring-1 ring-slate-900"
+                              : "bg-white hover:border-slate-300 hover:bg-slate-50"
+                          }`}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <p className="font-medium text-slate-900">
+                              {project.name}
+                            </p>
+                            <span className="shrink-0 text-xs text-slate-500">
+                              {formatCreatedAt(project.created_at)}
+                            </span>
+                          </div>
+
+                          <p className="mt-1 text-sm text-slate-600">
+                            {project.description ?? "설명이 없는 프로젝트입니다."}
+                          </p>
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
               </CardContent>
             </Card>
           </section>
 
-          {/* 컨테이너 목록 및 상태 영역 */}
           <section className="lg:col-span-8">
             <Card className="h-full">
               <CardHeader>
                 <CardTitle>컨테이너 목록 및 상태</CardTitle>
               </CardHeader>
+
               <CardContent className="space-y-4">
-                {selectedProject && (
+                {selectedProject ? (
                   <div className="rounded-lg border bg-white p-4">
                     <p className="text-sm font-medium text-slate-900">
                       선택된 프로젝트: {selectedProject.name}
                     </p>
                     <p className="mt-1 text-sm text-slate-600">
-                      {selectedProject.description}
+                      {selectedProject.description ??
+                        "설명이 없는 프로젝트입니다."}
                     </p>
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-500">
+                    먼저 프로젝트를 선택해주세요.
                   </div>
                 )}
 
-                {/* 컨테이너 목록 및 상태 조회 UI */}
                 <div className="overflow-hidden rounded-lg border bg-white">
                   <div className="grid grid-cols-3 border-b bg-slate-100 px-4 py-3 text-sm font-medium text-slate-700">
                     <span>이름</span>
@@ -183,7 +221,6 @@ export default function Dashboard() {
           </section>
         </div>
 
-        {/* 하단 상세 정보 영역 */}
         <section>
           <Card>
             <CardHeader className="space-y-4">
@@ -210,7 +247,6 @@ export default function Dashboard() {
             <CardContent>
               {activeTab === "metrics" ? (
                 <div className="space-y-3">
-                  {/* 메트릭 요약 영역 */}
                   <div className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-500">
                     추후 CPU / Memory 실시간 차트와 메트릭 히스토리 UI가
                     들어갈 영역입니다.
@@ -231,7 +267,6 @@ export default function Dashboard() {
                 </div>
               ) : (
                 <div className="space-y-3">
-                  {/* 로그 요약 영역 */}
                   <div className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-500">
                     추후 실시간 로그 스트리밍 및 로그 검색 UI가 들어갈
                     영역입니다.


### PR DESCRIPTION
## 연관 이슈
#32 

## 작업 내용
백엔드와 협의한 API 형식에 맞는 mock 응답 기반으로 프로젝트 목록 UI 를 연동했습니다.
프로젝트 목록은 axios + TanStack Query를 통해 조회 및 상태 관리하도록 구성했습니다.

프로젝트 mock의 id, name, description, ceated_at 필드는 계획서 DBML의 project 테이블 기준입니다.
응답 구조와 created_at / description 규칙은 합의 후 맞춘 내용입니다.

## 참고
컨테이너 목록은 아직 하드코딩된 mock 데이터를 사용하고 있습니다. 
컨테이너 API는 협의 후 MSW → 실제 API 순으로 전환할 예정입니다.
