### PR TITLE
feat: 컨테이너 목록/상태 조회 API 연결 및 project 기반 구조 제거

### DIFF
--- a/frontend/src/api/containerApi.js
+++ b/frontend/src/api/containerApi.js
@@ -1,7 +1,14 @@
 import { api } from "./client"
 
-// 선택된 프로젝트의 컨테이너 목록을 조회하는 API 함수
-export async function getContainers(projectId) {
-  const response = await api.get(`/projects/${projectId}/containers`)
-  return response.data
+// 컨테이너 목록을 실제 API에서 조회하고
+// 미완성 상태에서는 테스트 API로 대체
+export async function getContainers() {
+  try {
+    const response = await api.get("/container/")
+    return response.data
+  } catch (e) {
+    // fallback
+    const response = await api.get("/container/test")
+    return response.data
+  }
 }

--- a/frontend/src/components/dashboard/ContainerListSection.jsx
+++ b/frontend/src/components/dashboard/ContainerListSection.jsx
@@ -1,53 +1,38 @@
-// 선택된 프로젝트의 컨테이너 목록과 상태를 표시하는 섹션 컴포넌트
-
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { formatUpdatedAt } from "@/lib/dashboardFormat"
 import StatusBadge from "@/components/dashboard/StatusBadge"
 
+// 컨테이너 목록과 상태를 로딩/에러/빈 상태에 맞게 표시
 export default function ContainerListSection({
-  selectedProject,
-  selectedProjectId,
   containers,
   isLoading,
   isError,
   error,
 }) {
   return (
-    <section className="lg:col-span-8">
+    <section>
       <Card className="h-full">
         <CardHeader>
           <CardTitle>컨테이너 목록 및 상태</CardTitle>
         </CardHeader>
 
         <CardContent className="space-y-4">
-          {selectedProject ? (
-            <div className="rounded-lg border bg-white p-4">
-              <p className="text-sm font-medium text-slate-900">
-                선택된 프로젝트: {selectedProject.name}
-              </p>
-              <p className="mt-1 text-sm text-slate-600">
-                {selectedProject.description ?? "설명이 없는 프로젝트입니다."}
-              </p>
-            </div>
-          ) : (
-            <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-500">
-              먼저 프로젝트를 선택해주세요.
-            </div>
-          )}
+          <div className="rounded-lg border bg-white p-4">
+            <p className="text-sm font-medium text-slate-900">
+              현재 서버의 컨테이너 상태를 조회합니다.
+            </p>
+            <p className="mt-1 text-sm text-slate-600">
+              issue 1에서는 실제 API와 연결된 목록/상태 조회를 우선 반영합니다.
+            </p>
+          </div>
 
           <div className="overflow-hidden rounded-lg border bg-white">
-            <div className="grid grid-cols-4 border-b bg-slate-100 px-4 py-3 text-sm font-medium text-slate-700">
+            <div className="grid grid-cols-3 border-b bg-slate-100 px-4 py-3 text-sm font-medium text-slate-700">
               <span>이름</span>
               <span>이미지</span>
               <span>상태</span>
-              <span>업데이트</span>
             </div>
 
-            {selectedProjectId === null ? (
-              <div className="px-4 py-6 text-sm text-slate-500">
-                먼저 프로젝트를 선택해주세요.
-              </div>
-            ) : isLoading ? (
+            {isLoading ? (
               <div className="px-4 py-6 text-sm text-slate-500">
                 컨테이너 목록을 불러오는 중입니다.
               </div>
@@ -63,17 +48,14 @@ export default function ContainerListSection({
               <ul className="divide-y">
                 {containers.map((container) => (
                   <li
-                    key={container.id}
-                    className="grid grid-cols-4 items-center px-4 py-3 text-sm"
+                    key={container.container_id ?? container.id}
+                    className="grid grid-cols-3 items-center px-4 py-3 text-sm"
                   >
                     <span className="font-medium text-slate-900">
                       {container.name}
                     </span>
                     <span className="text-slate-600">{container.image}</span>
                     <StatusBadge status={container.status} />
-                    <span className="text-slate-500">
-                      {formatUpdatedAt(container.updated_at)}
-                    </span>
                   </li>
                 ))}
               </ul>

--- a/frontend/src/components/dashboard/StatusBadge.jsx
+++ b/frontend/src/components/dashboard/StatusBadge.jsx
@@ -1,12 +1,18 @@
-// 컨테이너 상태값에 따라 색상을 다르게 표시하는 컴포넌트
 
+// 컨테이너 상태값에 따라 다른 색상의 텍스트를 표시
 export default function StatusBadge({ status }) {
+  const normalizedStatus = String(status ?? "").toLowerCase()
+
   const statusClassName =
-    status === "running"
+    normalizedStatus === "running"
       ? "font-medium text-green-600"
-      : status === "restarting"
+      : normalizedStatus === "restarting"
       ? "font-medium text-yellow-600"
+      : normalizedStatus === "stopped" ||
+        normalizedStatus === "exited" ||
+        normalizedStatus === "paused"
+      ? "font-medium text-slate-500"
       : "font-medium text-red-500"
 
-  return <span className={statusClassName}>{status}</span>
+  return <span className={statusClassName}>{status ?? "unknown"}</span>
 }

--- a/frontend/src/hooks/useContainers.js
+++ b/frontend/src/hooks/useContainers.js
@@ -1,11 +1,10 @@
 import { useQuery } from "@tanstack/react-query"
 import { getContainers } from "@/api/containerApi"
 
-// 선택된 프로젝트 기준으로 컨테이너 목록 조회를 관리하는 커스텀 훅
-export function useContainers(projectId) {
+// 컨테이너 목록 조회를 TanStack Query로 관리
+export function useContainers() {
   return useQuery({
-    queryKey: ["containers", projectId],
-    queryFn: () => getContainers(projectId),
-    enabled: projectId !== null,
+    queryKey: ["containers"],
+    queryFn: getContainers,
   })
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,48 +1,23 @@
-import { useEffect, useMemo, useState } from "react"
-import { useProjects } from "@/hooks/useProjects"
+import { useState } from "react"
 import { useContainers } from "@/hooks/useContainers"
-import ProjectListSection from "@/components/dashboard/ProjectListSection"
 import ContainerListSection from "@/components/dashboard/ContainerListSection"
 import DetailPanelSection from "@/components/dashboard/DetailPanelSection"
 
+// 대시보드에서 컨테이너 목록을 직접 조회하고 상세 패널 탭 상태를 관리
 export default function Dashboard() {
-  // 현재 선택된 프로젝트와 상세 탭 상태를 관리
-  const [selectedProjectId, setSelectedProjectId] = useState(null)
   const [activeTab, setActiveTab] = useState("metrics")
 
-  // 프로젝트 목록 조회 상태를 TanStack Query로 관리
-  const {
-    data: projectData,
-    isLoading: isProjectsLoading,
-    isError: isProjectsError,
-    error: projectsError,
-  } = useProjects()
-
-  // API 응답에서 프로젝트 배열만 추출
-  const projects = projectData?.projects ?? []
-
-  // 프로젝트 목록이 로드되면 첫 프로젝트를 기본 선택
-  useEffect(() => {
-    if (projects.length > 0 && selectedProjectId === null) {
-      setSelectedProjectId(projects[0].id)
-    }
-  }, [projects, selectedProjectId])
-
-  // 선택된 프로젝트 id에 해당하는 프로젝트 정보를 계산
-  const selectedProject = useMemo(() => {
-    return projects.find((project) => project.id === selectedProjectId) ?? null
-  }, [projects, selectedProjectId])
-
-  // 선택된 프로젝트 기준으로 컨테이너 목록 조회 상태를 관리
   const {
     data: containerData,
     isLoading: isContainersLoading,
     isError: isContainersError,
     error: containersError,
-  } = useContainers(selectedProjectId)
+  } = useContainers()
 
-  // API 응답에서 컨테이너 배열만 추출
-  const containers = containerData?.containers ?? []
+  // 배열 응답과 객체 래핑 응답을 모두 안전하게 처리
+  const containers = Array.isArray(containerData)
+    ? containerData
+    : containerData?.containers ?? []
 
   return (
     <div className="min-h-screen bg-slate-50 px-6 py-8">
@@ -50,24 +25,12 @@ export default function Dashboard() {
         <div>
           <h1 className="text-3xl font-bold">Dashboard</h1>
           <p className="mt-1 text-sm text-slate-600">
-            프로젝트를 선택하고, 해당 프로젝트의 컨테이너 상태와 메트릭/로그
-            정보를 확인할 수 있습니다.
+            서버에 존재하는 컨테이너 목록과 현재 상태를 확인할 수 있습니다.
           </p>
         </div>
 
-        <div className="grid gap-6 lg:grid-cols-12">
-          <ProjectListSection
-            projects={projects}
-            selectedProjectId={selectedProjectId}
-            onSelectProject={setSelectedProjectId}
-            isLoading={isProjectsLoading}
-            isError={isProjectsError}
-            error={projectsError}
-          />
-
+        <div className="grid gap-6">
           <ContainerListSection
-            selectedProject={selectedProject}
-            selectedProjectId={selectedProjectId}
             containers={containers}
             isLoading={isContainersLoading}
             isError={isContainersError}


### PR DESCRIPTION
## 연관 이슈
#56 

## 작업 내용
1. 컨테이너 목록 조회 API 연결
- 기존 project 기반 조회 흐름 제거
- `/container/`를 우선 호출하도록 변경
- 백엔드 과도기 대응을 위해 `/container/test` fallback 추가

2.  컨테이너 조회 훅 구조 변경
- `useContainers(projectId)` → `useContainers()`로 변경
- queryKey를 `["containers"]`로 단순화

3. Dashboard 구조 리펙토링
- `useProjects`, `selectedProjectId`, `ProjectListSection` 제거
- 페이지 진입 시 컨테이너 목록을 직접 조회하도록 변경
- 설명 문구를 container 기준으로 수정

4. ContainerListSection 정리
- project 관련 props/UI 제거
- 이름 / 이미지 / 상태 중심 표시로 단순화
- `updated_at`은 현재 model 기준 미정의 상태라 제외

5. 상태 표시 로직 보강
- `running`, `restarting`, `exited`, `paused` 등 상태를 안전하게 처리하도록 개선
- 알 수 없는 상태는 fallback 스타일 적용

## 참고
- 백엔드 `docker_service.py`는 Docker SDK의 raw status 값을 그대로 사용하고 있음
- 프론트는 `running`, `restarting`, `exited`, `paused` 및 기타 상태를 fallback 방식으로 대응
- `projectApi`, `useProjects`, `ProjectListSection` 파일은 이번 PR에서 삭제하지 않고 미사용 상태로 유지
- 레이아웃 조정은 별도 issue에서 진행 예정
- 백엔드 `/container/` 미완성 구간 대응 위해 `/container/test` fallback 사용