### PR TITLE
feat: 상세 모니터링 페이지 추가 및 Dashboard 사이드바 연동

### DIFF
--- a/frontend/src/components/layout/SidebarNav.jsx
+++ b/frontend/src/components/layout/SidebarNav.jsx
@@ -1,24 +1,33 @@
-export default function SidebarNav({ activeMenu, onChangeMenu }) {
+import { useLocation, useNavigate } from "react-router-dom"
+
+export default function SidebarNav() {
+  const navigate = useNavigate()
+  const location = useLocation()
+
   const menuItems = [
     {
       id: "dashboard",
       label: "Dashboard",
-      description: "모니터링",
+      description: "컨테이너 현황",
+      path: "/dashboard",
+    },
+    {
+      id: "monitoring",
+      label: "Monitoring",
+      description: "상세 메트릭 · 로그",
+      path: "/monitoring",
     },
     {
       id: "compose-editor",
       label: "Compose Editor",
       description: "YAML 편집",
-    },
-    {
-      id: "logs",
-      label: "Logs",
-      description: "로그 조회",
+      path: "/compose-editor",
     },
     {
       id: "settings",
       label: "Settings",
       description: "환경 설정",
+      path: "/settings",
     },
   ]
 
@@ -39,13 +48,13 @@ export default function SidebarNav({ activeMenu, onChangeMenu }) {
 
         <nav className="mt-4 flex-1 space-y-2">
           {menuItems.map((item) => {
-            const isActive = activeMenu === item.id
+            const isActive = location.pathname === item.path
 
             return (
               <button
                 key={item.id}
                 type="button"
-                onClick={() => onChangeMenu?.(item.id)}
+                onClick={() => navigate(item.path)}
                 className={`group w-full rounded-2xl border px-4 py-3 text-left transition-all duration-200 ${
                   isActive
                     ? "border-cyan-500/30 bg-cyan-500/10 shadow-[0_0_0_1px_rgba(34,211,238,0.16)]"
@@ -61,6 +70,7 @@ export default function SidebarNav({ activeMenu, onChangeMenu }) {
                     >
                       {item.label}
                     </p>
+
                     <p
                       className={`mt-1 text-xs ${
                         isActive ? "text-cyan-300/80" : "text-slate-500"
@@ -92,8 +102,8 @@ export default function SidebarNav({ activeMenu, onChangeMenu }) {
               Design Preview
             </p>
             <p className="mt-1 text-xs leading-5 text-slate-500">
-              현재는 메뉴 UI만 반영된 상태이며, 실제 페이지 이동은 연결되지
-              않았습니다.
+              상세 모니터링 페이지에서 컨테이너별 메트릭과 로그를 함께 확인할
+              수 있습니다.
             </p>
           </div>
         </div>

--- a/frontend/src/components/monitoring/MonitoringChartPanel.jsx
+++ b/frontend/src/components/monitoring/MonitoringChartPanel.jsx
@@ -3,16 +3,18 @@ import { Button } from "@/components/ui/button"
 import MonitoringLineChart from "@/components/monitoring/MonitoringLineChart"
 import MonitoringSourceBadge from "@/components/monitoring/MonitoringSourceBadge"
 import MonitoringConnectionBadge from "@/components/monitoring/MonitoringConnectionBadge"
-import { useContainerMetricHistory } from "@/hooks/useContainerMetricHistory"
 
-export default function MonitoringChartPanel({ selectedContainer }) {
+export default function MonitoringChartPanel({
+  selectedContainer,
+  metricsResult,
+}) {
   const {
-    history,
-    latestMetric,
-    source,
-    connectionStatus,
-    reconnect,
-  } = useContainerMetricHistory(selectedContainer)
+    history = [],
+    latestMetric = null,
+    source = "mock-fallback",
+    connectionStatus = "idle",
+    reconnect = () => {},
+  } = metricsResult ?? {}
 
   return (
     <Card className="rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">

--- a/frontend/src/components/monitoring/MonitoringChartPanel.jsx
+++ b/frontend/src/components/monitoring/MonitoringChartPanel.jsx
@@ -1,0 +1,75 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+export default function MonitoringChartPanel({ selectedContainer }) {
+  return (
+    <Card className="rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">
+      <CardHeader className="space-y-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <CardTitle className="text-lg font-semibold tracking-tight text-slate-50">
+              CPU / Memory 라인차트
+            </CardTitle>
+            <p className="mt-2 text-sm text-slate-400">
+              선택한 컨테이너의 리소스 변화를 시간 흐름 기준으로 표시합니다.
+            </p>
+          </div>
+
+          <span className="w-fit rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
+            Recharts 준비 영역
+          </span>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {!selectedContainer ? (
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-5 text-sm text-slate-400">
+            컨테이너를 선택하면 CPU / Memory 라인차트가 표시됩니다.
+          </div>
+        ) : (
+          <div className="grid gap-4 xl:grid-cols-2">
+            <ChartPlaceholder
+              title="CPU Usage"
+              value="--%"
+              helper="mock history 연결 예정"
+            />
+
+            <ChartPlaceholder
+              title="Memory Usage"
+              value="--%"
+              helper="mock history 연결 예정"
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ChartPlaceholder({ title, value, helper }) {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-slate-800 bg-[linear-gradient(to_bottom,rgba(15,23,42,0.96),rgba(2,6,23,0.96))]">
+      <div className="flex items-start justify-between gap-3 border-b border-slate-800 p-4">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+            Metric
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-100">{title}</p>
+        </div>
+
+        <span className="rounded-full border border-slate-700 bg-slate-950 px-3 py-1 text-xs text-slate-400">
+          {value}
+        </span>
+      </div>
+
+      <div className="flex h-[260px] items-center justify-center bg-slate-950/40 p-4">
+        <div className="text-center">
+          <div className="mx-auto h-14 w-14 rounded-full border border-cyan-500/20 bg-cyan-500/10 shadow-[0_0_30px_rgba(34,211,238,0.10)]" />
+          <p className="mt-4 text-sm font-medium text-slate-300">
+            LineChart Area
+          </p>
+          <p className="mt-1 text-xs text-slate-500">{helper}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/monitoring/MonitoringChartPanel.jsx
+++ b/frontend/src/components/monitoring/MonitoringChartPanel.jsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import MonitoringLineChart from "@/components/monitoring/MonitoringLineChart"
-import { useMockContainerMetricHistory } from "@/hooks/useMockContainerMetricHistory"
+import { useContainerMetricHistory } from "@/hooks/useContainerMetricHistory"
 
 export default function MonitoringChartPanel({ selectedContainer }) {
   const { history, latestMetric } =
-    useMockContainerMetricHistory(selectedContainer)
+    useContainerMetricHistory(selectedContainer)
 
   return (
     <Card className="rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">

--- a/frontend/src/components/monitoring/MonitoringChartPanel.jsx
+++ b/frontend/src/components/monitoring/MonitoringChartPanel.jsx
@@ -1,6 +1,11 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import MonitoringLineChart from "@/components/monitoring/MonitoringLineChart"
+import { useMockContainerMetricHistory } from "@/hooks/useMockContainerMetricHistory"
 
 export default function MonitoringChartPanel({ selectedContainer }) {
+  const { history, latestMetric } =
+    useMockContainerMetricHistory(selectedContainer)
+
   return (
     <Card className="rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">
       <CardHeader className="space-y-3">
@@ -10,13 +15,18 @@ export default function MonitoringChartPanel({ selectedContainer }) {
               CPU / Memory 라인차트
             </CardTitle>
             <p className="mt-2 text-sm text-slate-400">
-              선택한 컨테이너의 리소스 변화를 시간 흐름 기준으로 표시합니다.
+              선택한 컨테이너의 리소스 변화를 3초 간격 mock 데이터로 표시합니다.
             </p>
           </div>
 
-          <span className="w-fit rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
-            Recharts 준비 영역
-          </span>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="w-fit rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
+              Recharts
+            </span>
+            <span className="w-fit rounded-full border border-slate-700 bg-slate-950 px-3 py-1 text-xs text-slate-400">
+              mock polling
+            </span>
+          </div>
         </div>
       </CardHeader>
 
@@ -26,18 +36,61 @@ export default function MonitoringChartPanel({ selectedContainer }) {
             컨테이너를 선택하면 CPU / Memory 라인차트가 표시됩니다.
           </div>
         ) : (
-          <div className="grid gap-4 xl:grid-cols-2">
-            <ChartPlaceholder
-              title="CPU Usage"
-              value="--%"
-              helper="mock history 연결 예정"
-            />
+          <div className="space-y-4">
+            <div className="grid gap-4 xl:grid-cols-2">
+              <MonitoringLineChart
+                title="CPU Usage"
+                description="cpu_percent"
+                data={history}
+                dataKey="cpu_percent"
+                valueSuffix="%"
+                accentColor="#22d3ee"
+              />
 
-            <ChartPlaceholder
-              title="Memory Usage"
-              value="--%"
-              helper="mock history 연결 예정"
-            />
+              <MonitoringLineChart
+                title="Memory Usage"
+                description="memory_percent"
+                data={history}
+                dataKey="memory_percent"
+                valueSuffix="%"
+                accentColor="#22c55e"
+              />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-3">
+              <MetricSnapshotCard
+                label="CPU"
+                value={
+                  latestMetric
+                    ? `${latestMetric.cpu_percent.toFixed(1)}%`
+                    : "--%"
+                }
+                helper="현재 CPU 사용률"
+                tone="cyan"
+              />
+
+              <MetricSnapshotCard
+                label="Memory Used"
+                value={
+                  latestMetric
+                    ? `${latestMetric.memory_usage_mb.toFixed(1)} MB`
+                    : "-- MB"
+                }
+                helper="현재 메모리 사용량"
+                tone="emerald"
+              />
+
+              <MetricSnapshotCard
+                label="Memory Limit"
+                value={
+                  latestMetric
+                    ? `${latestMetric.memory_limit_mb.toFixed(1)} MB`
+                    : "-- MB"
+                }
+                helper="mock 기준 메모리 한도"
+                tone="slate"
+              />
+            </div>
           </div>
         )}
       </CardContent>
@@ -45,31 +98,35 @@ export default function MonitoringChartPanel({ selectedContainer }) {
   )
 }
 
-function ChartPlaceholder({ title, value, helper }) {
+function MetricSnapshotCard({ label, value, helper, tone = "slate" }) {
+  const toneClassName =
+    tone === "cyan"
+      ? "border-cyan-500/10 bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.10),transparent_35%),linear-gradient(to_bottom,rgba(15,23,42,0.96),rgba(2,6,23,0.96))]"
+      : tone === "emerald"
+      ? "border-emerald-500/10 bg-[radial-gradient(circle_at_top_left,rgba(34,197,94,0.10),transparent_35%),linear-gradient(to_bottom,rgba(15,23,42,0.96),rgba(2,6,23,0.96))]"
+      : "border-slate-700 bg-[radial-gradient(circle_at_top_left,rgba(100,116,139,0.12),transparent_35%),linear-gradient(to_bottom,rgba(15,23,42,0.96),rgba(2,6,23,0.96))]"
+
+  const dotClassName =
+    tone === "cyan"
+      ? "bg-cyan-400 shadow-[0_0_10px_rgba(34,211,238,0.8)]"
+      : tone === "emerald"
+      ? "bg-emerald-400 shadow-[0_0_10px_rgba(52,211,153,0.8)]"
+      : "bg-slate-400 shadow-[0_0_10px_rgba(148,163,184,0.45)]"
+
   return (
-    <div className="overflow-hidden rounded-2xl border border-slate-800 bg-[linear-gradient(to_bottom,rgba(15,23,42,0.96),rgba(2,6,23,0.96))]">
-      <div className="flex items-start justify-between gap-3 border-b border-slate-800 p-4">
-        <div>
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
-            Metric
-          </p>
-          <p className="mt-2 text-sm font-semibold text-slate-100">{title}</p>
-        </div>
-
-        <span className="rounded-full border border-slate-700 bg-slate-950 px-3 py-1 text-xs text-slate-400">
-          {value}
-        </span>
+    <div className={`rounded-2xl border p-4 shadow-sm ${toneClassName}`}>
+      <div className="flex items-center gap-2">
+        <span className={`h-2 w-2 rounded-full ${dotClassName}`} />
+        <p className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+          {label}
+        </p>
       </div>
 
-      <div className="flex h-[260px] items-center justify-center bg-slate-950/40 p-4">
-        <div className="text-center">
-          <div className="mx-auto h-14 w-14 rounded-full border border-cyan-500/20 bg-cyan-500/10 shadow-[0_0_30px_rgba(34,211,238,0.10)]" />
-          <p className="mt-4 text-sm font-medium text-slate-300">
-            LineChart Area
-          </p>
-          <p className="mt-1 text-xs text-slate-500">{helper}</p>
-        </div>
-      </div>
+      <p className="mt-4 text-3xl font-semibold tracking-tight text-slate-50">
+        {value}
+      </p>
+
+      <p className="mt-2 text-xs text-slate-500">{helper}</p>
     </div>
   )
 }

--- a/frontend/src/components/monitoring/MonitoringChartPanel.jsx
+++ b/frontend/src/components/monitoring/MonitoringChartPanel.jsx
@@ -3,7 +3,7 @@ import MonitoringLineChart from "@/components/monitoring/MonitoringLineChart"
 import { useContainerMetricHistory } from "@/hooks/useContainerMetricHistory"
 
 export default function MonitoringChartPanel({ selectedContainer }) {
-  const { history, latestMetric } =
+  const { history, latestMetric, source, connectionStatus } =
     useContainerMetricHistory(selectedContainer)
 
   return (
@@ -15,16 +15,16 @@ export default function MonitoringChartPanel({ selectedContainer }) {
               CPU / Memory 라인차트
             </CardTitle>
             <p className="mt-2 text-sm text-slate-400">
-              선택한 컨테이너의 리소스 변화를 3초 간격 mock 데이터로 표시합니다.
+              WebSocket 연결 성공 시 real 데이터를 사용하고, 연결 전에는 mock
+              fallback 데이터를 표시합니다.
             </p>
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
+            <SourceBadge source={source} />
+            <ConnectionBadge status={connectionStatus} />
             <span className="w-fit rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
               Recharts
-            </span>
-            <span className="w-fit rounded-full border border-slate-700 bg-slate-950 px-3 py-1 text-xs text-slate-400">
-              mock polling
             </span>
           </div>
         </div>
@@ -87,7 +87,7 @@ export default function MonitoringChartPanel({ selectedContainer }) {
                     ? `${latestMetric.memory_limit_mb.toFixed(1)} MB`
                     : "-- MB"
                 }
-                helper="mock 기준 메모리 한도"
+                helper="메모리 한도"
                 tone="slate"
               />
             </div>
@@ -95,6 +95,47 @@ export default function MonitoringChartPanel({ selectedContainer }) {
         )}
       </CardContent>
     </Card>
+  )
+}
+
+function SourceBadge({ source }) {
+  const className =
+    source === "real"
+      ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-300"
+      : source === "mock-fallback"
+      ? "border-amber-500/20 bg-amber-500/10 text-amber-300"
+      : "border-slate-700 bg-slate-950 text-slate-400"
+
+  const label =
+    source === "real"
+      ? "REAL WS"
+      : source === "mock-fallback"
+      ? "MOCK FALLBACK"
+      : "MOCK"
+
+  return (
+    <span className={`w-fit rounded-full border px-3 py-1 text-xs ${className}`}>
+      {label}
+    </span>
+  )
+}
+
+function ConnectionBadge({ status }) {
+  const className =
+    status === "connected"
+      ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-300"
+      : status === "connecting"
+      ? "border-cyan-500/20 bg-cyan-500/10 text-cyan-300"
+      : status === "fallback"
+      ? "border-amber-500/20 bg-amber-500/10 text-amber-300"
+      : status === "error"
+      ? "border-rose-500/20 bg-rose-500/10 text-rose-300"
+      : "border-slate-700 bg-slate-950 text-slate-400"
+
+  return (
+    <span className={`w-fit rounded-full border px-3 py-1 text-xs ${className}`}>
+      {status ?? "idle"}
+    </span>
   )
 }
 

--- a/frontend/src/components/monitoring/MonitoringChartPanel.jsx
+++ b/frontend/src/components/monitoring/MonitoringChartPanel.jsx
@@ -1,10 +1,18 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
 import MonitoringLineChart from "@/components/monitoring/MonitoringLineChart"
+import MonitoringSourceBadge from "@/components/monitoring/MonitoringSourceBadge"
+import MonitoringConnectionBadge from "@/components/monitoring/MonitoringConnectionBadge"
 import { useContainerMetricHistory } from "@/hooks/useContainerMetricHistory"
 
 export default function MonitoringChartPanel({ selectedContainer }) {
-  const { history, latestMetric, source, connectionStatus } =
-    useContainerMetricHistory(selectedContainer)
+  const {
+    history,
+    latestMetric,
+    source,
+    connectionStatus,
+    reconnect,
+  } = useContainerMetricHistory(selectedContainer)
 
   return (
     <Card className="rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">
@@ -21,11 +29,22 @@ export default function MonitoringChartPanel({ selectedContainer }) {
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
-            <SourceBadge source={source} />
-            <ConnectionBadge status={connectionStatus} />
+            <MonitoringSourceBadge source={source} />
+            <MonitoringConnectionBadge status={connectionStatus} />
+
             <span className="w-fit rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
               Recharts
             </span>
+
+            <Button
+              type="button"
+              variant="outline"
+              onClick={reconnect}
+              disabled={!selectedContainer || connectionStatus === "connecting"}
+              className="h-8 border-slate-700 bg-slate-950 px-3 text-xs text-slate-200 transition-all duration-150 hover:-translate-y-[1px] hover:bg-slate-800 hover:text-slate-50 disabled:opacity-50"
+            >
+              {connectionStatus === "connecting" ? "연결 중" : "WS 재연결"}
+            </Button>
           </div>
         </div>
       </CardHeader>
@@ -95,47 +114,6 @@ export default function MonitoringChartPanel({ selectedContainer }) {
         )}
       </CardContent>
     </Card>
-  )
-}
-
-function SourceBadge({ source }) {
-  const className =
-    source === "real"
-      ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-300"
-      : source === "mock-fallback"
-      ? "border-amber-500/20 bg-amber-500/10 text-amber-300"
-      : "border-slate-700 bg-slate-950 text-slate-400"
-
-  const label =
-    source === "real"
-      ? "REAL WS"
-      : source === "mock-fallback"
-      ? "MOCK FALLBACK"
-      : "MOCK"
-
-  return (
-    <span className={`w-fit rounded-full border px-3 py-1 text-xs ${className}`}>
-      {label}
-    </span>
-  )
-}
-
-function ConnectionBadge({ status }) {
-  const className =
-    status === "connected"
-      ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-300"
-      : status === "connecting"
-      ? "border-cyan-500/20 bg-cyan-500/10 text-cyan-300"
-      : status === "fallback"
-      ? "border-amber-500/20 bg-amber-500/10 text-amber-300"
-      : status === "error"
-      ? "border-rose-500/20 bg-rose-500/10 text-rose-300"
-      : "border-slate-700 bg-slate-950 text-slate-400"
-
-  return (
-    <span className={`w-fit rounded-full border px-3 py-1 text-xs ${className}`}>
-      {status ?? "idle"}
-    </span>
   )
 }
 

--- a/frontend/src/components/monitoring/MonitoringConnectionBadge.jsx
+++ b/frontend/src/components/monitoring/MonitoringConnectionBadge.jsx
@@ -1,0 +1,18 @@
+export default function MonitoringConnectionBadge({ status }) {
+  const className =
+    status === "connected"
+      ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-300"
+      : status === "connecting"
+      ? "border-cyan-500/20 bg-cyan-500/10 text-cyan-300"
+      : status === "fallback"
+      ? "border-amber-500/20 bg-amber-500/10 text-amber-300"
+      : status === "error"
+      ? "border-rose-500/20 bg-rose-500/10 text-rose-300"
+      : "border-slate-700 bg-slate-950 text-slate-400"
+
+  return (
+    <span className={`w-fit rounded-full border px-3 py-1 text-xs ${className}`}>
+      {status ?? "idle"}
+    </span>
+  )
+}

--- a/frontend/src/components/monitoring/MonitoringContainerList.jsx
+++ b/frontend/src/components/monitoring/MonitoringContainerList.jsx
@@ -1,0 +1,134 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import StatusBadge from "@/components/dashboard/StatusBadge"
+
+export default function MonitoringContainerList({
+  containers,
+  isLoading,
+  isError,
+  error,
+  selectedContainer,
+  onSelectContainer,
+}) {
+  const selectedContainerId =
+    selectedContainer?.container_id ?? selectedContainer?.id ?? null
+
+  return (
+    <section>
+      <Card className="h-full rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">
+        <CardHeader className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-lg font-semibold tracking-tight text-slate-50">
+              컨테이너 목록
+            </CardTitle>
+
+            <span className="rounded-full border border-slate-700 bg-slate-950 px-3 py-1 text-xs text-slate-400">
+              총 {containers.length}개
+            </span>
+          </div>
+
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-4">
+            <p className="text-sm font-medium text-slate-200">
+              상세 모니터링 대상 선택
+            </p>
+            <p className="mt-1 text-sm leading-6 text-slate-400">
+              선택한 컨테이너의 메트릭 변화와 로그 스트림을 우측에서 확인합니다.
+            </p>
+          </div>
+        </CardHeader>
+
+        <CardContent>
+          {isLoading ? (
+            <StateBox message="컨테이너 목록을 불러오는 중입니다." />
+          ) : isError ? (
+            <StateBox
+              variant="error"
+              message={error?.message ?? "컨테이너 목록을 불러오지 못했습니다."}
+            />
+          ) : containers.length === 0 ? (
+            <StateBox message="표시할 컨테이너가 없습니다." />
+          ) : (
+            <ul className="space-y-3 animate-fade-in-up">
+              {containers.map((container) => {
+                const currentId = container.container_id ?? container.id
+                const isSelected = selectedContainerId === currentId
+
+                return (
+                  <li key={currentId}>
+                    <button
+                      type="button"
+                      onClick={() => onSelectContainer(container)}
+                      className={`group relative w-full cursor-pointer overflow-hidden rounded-2xl border p-4 text-left transition-all duration-200 ease-out active:scale-[0.995] ${
+                        isSelected
+                          ? "border-cyan-400/60 bg-cyan-500/12 shadow-[0_0_0_1px_rgba(34,211,238,0.22),0_12px_30px_rgba(34,211,238,0.10)]"
+                          : "border-slate-800 bg-slate-950/70 hover:-translate-y-[2px] hover:border-slate-700 hover:bg-slate-900/70 hover:shadow-[0_10px_25px_rgba(2,6,23,0.60)]"
+                      }`}
+                    >
+                      <span
+                        className={`absolute inset-y-0 left-0 w-1 rounded-r-full transition-all duration-200 ${
+                          isSelected
+                            ? "bg-cyan-400 shadow-[0_0_18px_rgba(34,211,238,0.45)]"
+                            : "bg-transparent group-hover:bg-slate-700"
+                        }`}
+                      />
+
+                      <div className="flex flex-col gap-4">
+                        <div className="min-w-0 space-y-2 pl-1">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className={`h-2.5 w-2.5 rounded-full transition-all duration-200 group-hover:scale-110 ${
+                                isSelected
+                                  ? "bg-cyan-300 shadow-[0_0_10px_rgba(103,232,249,0.9)]"
+                                  : "bg-cyan-400"
+                              }`}
+                            />
+
+                            <p
+                              className={`truncate text-sm font-semibold transition-colors duration-200 ${
+                                isSelected ? "text-cyan-50" : "text-slate-100"
+                              }`}
+                            >
+                              {container.name}
+                            </p>
+                          </div>
+
+                          <p
+                            className={`truncate text-sm transition-colors duration-200 ${
+                              isSelected ? "text-slate-300" : "text-slate-400"
+                            }`}
+                          >
+                            {container.image}
+                          </p>
+                        </div>
+
+                        <div className="flex items-center justify-between gap-3 pl-1">
+                          <StatusBadge status={container.status} />
+
+                          <span className="text-xs text-slate-500">
+                            {currentId}
+                          </span>
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  )
+}
+
+function StateBox({ message, variant = "default" }) {
+  const className =
+    variant === "error"
+      ? "border-rose-500/30 bg-rose-500/10 text-rose-300"
+      : "border-slate-800 bg-slate-950/70 text-slate-400"
+
+  return (
+    <div className={`rounded-2xl border p-4 text-sm ${className}`}>
+      {message}
+    </div>
+  )
+}

--- a/frontend/src/components/monitoring/MonitoringLineChart.jsx
+++ b/frontend/src/components/monitoring/MonitoringLineChart.jsx
@@ -41,7 +41,7 @@ export default function MonitoringLineChart({
 
       <div className="h-[280px] bg-slate-950/40 p-4">
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={data} margin={{ top: 12, right: 16, bottom: 0, left: -18 }}>
+          <LineChart data={data} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
             <defs>
               <linearGradient id={`${dataKey}-gradient`} x1="0" y1="0" x2="0" y2="1">
                 <stop offset="5%" stopColor={accentColor} stopOpacity={0.28} />
@@ -61,10 +61,11 @@ export default function MonitoringLineChart({
 
             <YAxis
               domain={[0, 100]}
+              ticks={[0, 25, 50, 75, 100]}
               tick={{ fill: "#64748b", fontSize: 11 }}
               tickLine={false}
               axisLine={false}
-              width={42}
+              width={48}
               tickFormatter={(value) => `${value}%`}
             />
 

--- a/frontend/src/components/monitoring/MonitoringLineChart.jsx
+++ b/frontend/src/components/monitoring/MonitoringLineChart.jsx
@@ -1,0 +1,119 @@
+import {
+  Area,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+export default function MonitoringLineChart({
+  title,
+  description,
+  data,
+  dataKey,
+  valueSuffix = "%",
+  accentColor = "#22d3ee",
+}) {
+  const latestValue = data?.length ? data[data.length - 1]?.[dataKey] : null
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-slate-800 bg-[linear-gradient(to_bottom,rgba(15,23,42,0.96),rgba(2,6,23,0.96))]">
+      <div className="flex items-start justify-between gap-3 border-b border-slate-800 p-4">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+            Metric
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-100">{title}</p>
+          {description ? (
+            <p className="mt-1 text-xs text-slate-500">{description}</p>
+          ) : null}
+        </div>
+
+        <span className="rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
+          {typeof latestValue === "number"
+            ? `${latestValue.toFixed(1)}${valueSuffix}`
+            : `--${valueSuffix}`}
+        </span>
+      </div>
+
+      <div className="h-[280px] bg-slate-950/40 p-4">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 12, right: 16, bottom: 0, left: -18 }}>
+            <defs>
+              <linearGradient id={`${dataKey}-gradient`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={accentColor} stopOpacity={0.28} />
+                <stop offset="95%" stopColor={accentColor} stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+
+            <CartesianGrid stroke="#1e293b" strokeDasharray="4 4" vertical={false} />
+
+            <XAxis
+              dataKey="time"
+              tick={{ fill: "#64748b", fontSize: 11 }}
+              tickLine={false}
+              axisLine={false}
+              minTickGap={18}
+            />
+
+            <YAxis
+              domain={[0, 100]}
+              tick={{ fill: "#64748b", fontSize: 11 }}
+              tickLine={false}
+              axisLine={false}
+              width={42}
+              tickFormatter={(value) => `${value}%`}
+            />
+
+            <Tooltip
+              cursor={{ stroke: "#334155", strokeWidth: 1 }}
+              content={<ChartTooltip dataKey={dataKey} valueSuffix={valueSuffix} />}
+            />
+
+            <Area
+              type="monotone"
+              dataKey={dataKey}
+              stroke="none"
+              fill={`url(#${dataKey}-gradient)`}
+              isAnimationActive
+            />
+
+            <Line
+              type="monotone"
+              dataKey={dataKey}
+              stroke={accentColor}
+              strokeWidth={2.5}
+              dot={false}
+              activeDot={{
+                r: 4,
+                stroke: accentColor,
+                strokeWidth: 2,
+                fill: "#020617",
+              }}
+              isAnimationActive
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}
+
+function ChartTooltip({ active, payload, label, dataKey, valueSuffix }) {
+  if (!active || !payload?.length) return null
+
+  const value = payload.find((item) => item.dataKey === dataKey)?.value
+
+  return (
+    <div className="rounded-xl border border-slate-700 bg-slate-950/95 px-3 py-2 shadow-xl">
+      <p className="text-xs text-slate-500">{label}</p>
+      <p className="mt-1 text-sm font-semibold text-slate-100">
+        {typeof value === "number" ? value.toFixed(1) : "--"}
+        {valueSuffix}
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/monitoring/MonitoringLogBody.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogBody.jsx
@@ -1,0 +1,28 @@
+import { forwardRef } from "react"
+import MonitoringLogLine from "@/components/monitoring/MonitoringLogLine"
+
+const MonitoringLogBody = forwardRef(function MonitoringLogBody({ logs }, ref) {
+  return (
+    <div
+      ref={ref}
+      className="max-h-[380px] min-h-[280px] space-y-2 overflow-y-auto bg-[#020617] p-4 font-mono text-sm"
+    >
+      {logs.length === 0 ? (
+        <div className="rounded-xl border border-slate-800 bg-slate-950/80 px-4 py-3 text-sm text-slate-500">
+          표시할 로그가 없습니다.
+        </div>
+      ) : (
+        logs.map((log, index) => (
+          <MonitoringLogLine
+            key={`${log.time}-${log.stream}-${index}`}
+            time={log.time}
+            stream={log.stream}
+            message={log.message}
+          />
+        ))
+      )}
+    </div>
+  )
+})
+
+export default MonitoringLogBody

--- a/frontend/src/components/monitoring/MonitoringLogHeader.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogHeader.jsx
@@ -1,4 +1,5 @@
 import { CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
 import MonitoringSourceBadge from "@/components/monitoring/MonitoringSourceBadge"
 import MonitoringConnectionBadge from "@/components/monitoring/MonitoringConnectionBadge"
 
@@ -6,6 +7,8 @@ export default function MonitoringLogHeader({
   source,
   connectionStatus,
   isPaused,
+  selectedContainer,
+  onReconnect,
 }) {
   return (
     <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -32,6 +35,16 @@ export default function MonitoringLogHeader({
         >
           {isPaused ? "paused" : "streaming"}
         </span>
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onReconnect}
+          disabled={!selectedContainer || connectionStatus === "connecting"}
+          className="h-8 border-slate-700 bg-slate-950 px-3 text-xs text-slate-200 transition-all duration-150 hover:-translate-y-[1px] hover:bg-slate-800 hover:text-slate-50 disabled:opacity-50"
+        >
+          {connectionStatus === "connecting" ? "연결 중" : "WS 재연결"}
+        </Button>
       </div>
     </div>
   )

--- a/frontend/src/components/monitoring/MonitoringLogHeader.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogHeader.jsx
@@ -1,0 +1,38 @@
+import { CardTitle } from "@/components/ui/card"
+import MonitoringSourceBadge from "@/components/monitoring/MonitoringSourceBadge"
+import MonitoringConnectionBadge from "@/components/monitoring/MonitoringConnectionBadge"
+
+export default function MonitoringLogHeader({
+  source,
+  connectionStatus,
+  isPaused,
+}) {
+  return (
+    <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+      <div>
+        <CardTitle className="text-lg font-semibold tracking-tight text-slate-50">
+          실시간 로그 터미널
+        </CardTitle>
+        <p className="mt-2 text-sm text-slate-400">
+          WebSocket 연결 성공 시 real 로그를 사용하고, 연결 전에는 mock
+          fallback 로그를 표시합니다.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <MonitoringSourceBadge source={source} />
+        <MonitoringConnectionBadge status={connectionStatus} />
+
+        <span
+          className={`w-fit rounded-full border px-3 py-1 text-xs ${
+            isPaused
+              ? "border-amber-500/20 bg-amber-500/10 text-amber-300"
+              : "border-emerald-500/20 bg-emerald-500/10 text-emerald-300"
+          }`}
+        >
+          {isPaused ? "paused" : "streaming"}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/monitoring/MonitoringLogLine.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogLine.jsx
@@ -1,0 +1,18 @@
+export default function MonitoringLogLine({ time, stream, message }) {
+  const streamClassName =
+    stream === "stderr" ? "text-rose-300" : "text-cyan-300"
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-950/80 px-4 py-3">
+      <div className="flex flex-col gap-1 md:flex-row md:items-start md:gap-3">
+        <span className="shrink-0 text-xs text-slate-500">{time}</span>
+
+        <span className={`shrink-0 text-xs font-semibold ${streamClassName}`}>
+          {stream}
+        </span>
+
+        <p className="min-w-0 text-sm text-slate-300">{message}</p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
@@ -1,0 +1,83 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import ToolbarChip from "@/components/dashboard/ToolbarChip"
+import LogLine from "@/components/dashboard/LogLine"
+import { CONTAINER_LOG_PREVIEW } from "@/mocks/data/containerLogs"
+
+export default function MonitoringLogTerminal({ selectedContainer }) {
+  return (
+    <Card className="rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">
+      <CardHeader className="space-y-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <CardTitle className="text-lg font-semibold tracking-tight text-slate-50">
+              실시간 로그 터미널
+            </CardTitle>
+            <p className="mt-2 text-sm text-slate-400">
+              선택한 컨테이너의 stdout / stderr 로그를 터미널 형태로 표시합니다.
+            </p>
+          </div>
+
+          <span className="w-fit rounded-full border border-slate-700 bg-slate-950 px-3 py-1 text-xs text-slate-400">
+            mock logs
+          </span>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {!selectedContainer ? (
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-5 text-sm text-slate-400">
+            컨테이너를 선택하면 로그 터미널이 표시됩니다.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/80">
+            <div className="flex flex-col gap-3 border-b border-slate-800 bg-slate-950/90 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex items-center gap-3">
+                <div className="flex items-center gap-1.5">
+                  <span className="h-2.5 w-2.5 rounded-full bg-rose-400" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
+                </div>
+
+                <div>
+                  <p className="text-sm font-medium text-slate-100">
+                    로그 스트림
+                  </p>
+                  <p className="text-xs text-slate-500">
+                    {selectedContainer.name} · {selectedContainer.image}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-slate-700 bg-slate-900 px-3 py-1 text-xs text-slate-400">
+                  preview
+                </span>
+                <span className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-300">
+                  connected
+                </span>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 border-b border-slate-800 bg-slate-950/60 px-4 py-3">
+              <ToolbarChip label="stdout" active />
+              <ToolbarChip label="stderr" />
+              <ToolbarChip label="자동 스크롤" active />
+              <ToolbarChip label="필터 예정" />
+            </div>
+
+            <div className="max-h-[360px] space-y-2 overflow-y-auto bg-[#020617] p-4 font-mono text-sm">
+              {CONTAINER_LOG_PREVIEW.map((log, index) => (
+                <LogLine
+                  key={`${log.time}-${log.level}-${index}`}
+                  time={log.time}
+                  level={log.level}
+                  message={log.message}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
@@ -16,6 +16,7 @@ export default function MonitoringLogTerminal({ selectedContainer }) {
     togglePause,
     source,
     connectionStatus,
+    reconnect,
   } = useContainerLogs(selectedContainer)
 
   const filteredLogs = useMemo(() => {
@@ -36,6 +37,8 @@ export default function MonitoringLogTerminal({ selectedContainer }) {
           source={source}
           connectionStatus={connectionStatus}
           isPaused={isPaused}
+          selectedContainer={selectedContainer}
+          onReconnect={reconnect}
         />
       </CardHeader>
 
@@ -55,10 +58,7 @@ export default function MonitoringLogTerminal({ selectedContainer }) {
               onClearLogs={clearLogs}
             />
 
-            <MonitoringLogBody
-              ref={terminalRef}
-              logs={filteredLogs}
-            />
+            <MonitoringLogBody ref={terminalRef} logs={filteredLogs} />
           </div>
         )}
       </CardContent>

--- a/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
@@ -1,9 +1,28 @@
+import { useEffect, useMemo, useRef, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
 import ToolbarChip from "@/components/dashboard/ToolbarChip"
-import LogLine from "@/components/dashboard/LogLine"
-import { CONTAINER_LOG_PREVIEW } from "@/mocks/data/containerLogs"
+import { useMockContainerLogs } from "@/hooks/useMockContainerLogs"
 
 export default function MonitoringLogTerminal({ selectedContainer }) {
+  const [activeStream, setActiveStream] = useState("all")
+  const terminalRef = useRef(null)
+
+  const { logs, isPaused, clearLogs, togglePause } =
+    useMockContainerLogs(selectedContainer)
+
+  const filteredLogs = useMemo(() => {
+    if (activeStream === "all") return logs
+
+    return logs.filter((log) => log.stream === activeStream)
+  }, [logs, activeStream])
+
+  useEffect(() => {
+    if (!terminalRef.current || isPaused) return
+
+    terminalRef.current.scrollTop = terminalRef.current.scrollHeight
+  }, [filteredLogs, isPaused])
+
   return (
     <Card className="rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">
       <CardHeader className="space-y-3">
@@ -17,9 +36,21 @@ export default function MonitoringLogTerminal({ selectedContainer }) {
             </p>
           </div>
 
-          <span className="w-fit rounded-full border border-slate-700 bg-slate-950 px-3 py-1 text-xs text-slate-400">
-            mock logs
-          </span>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="w-fit rounded-full border border-slate-700 bg-slate-950 px-3 py-1 text-xs text-slate-400">
+              mock stream
+            </span>
+
+            <span
+              className={`w-fit rounded-full border px-3 py-1 text-xs ${
+                isPaused
+                  ? "border-amber-500/20 bg-amber-500/10 text-amber-300"
+                  : "border-emerald-500/20 bg-emerald-500/10 text-emerald-300"
+              }`}
+            >
+              {isPaused ? "paused" : "connected"}
+            </span>
+          </div>
         </div>
       </CardHeader>
 
@@ -49,35 +80,90 @@ export default function MonitoringLogTerminal({ selectedContainer }) {
               </div>
 
               <div className="flex flex-wrap items-center gap-2">
-                <span className="rounded-full border border-slate-700 bg-slate-900 px-3 py-1 text-xs text-slate-400">
-                  preview
-                </span>
-                <span className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-300">
-                  connected
-                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={togglePause}
+                  className="h-8 border-slate-700 bg-slate-950 px-3 text-xs text-slate-200 transition-all duration-150 hover:-translate-y-[1px] hover:bg-slate-800 hover:text-slate-50"
+                >
+                  {isPaused ? "재개" : "일시정지"}
+                </Button>
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={clearLogs}
+                  className="h-8 border-slate-700 bg-slate-950 px-3 text-xs text-slate-200 transition-all duration-150 hover:-translate-y-[1px] hover:bg-slate-800 hover:text-slate-50"
+                >
+                  지우기
+                </Button>
               </div>
             </div>
 
             <div className="flex flex-wrap items-center gap-2 border-b border-slate-800 bg-slate-950/60 px-4 py-3">
-              <ToolbarChip label="stdout" active />
-              <ToolbarChip label="stderr" />
-              <ToolbarChip label="자동 스크롤" active />
-              <ToolbarChip label="필터 예정" />
+              <button type="button" onClick={() => setActiveStream("all")}>
+                <ToolbarChip label="all" active={activeStream === "all"} />
+              </button>
+
+              <button type="button" onClick={() => setActiveStream("stdout")}>
+                <ToolbarChip
+                  label="stdout"
+                  active={activeStream === "stdout"}
+                />
+              </button>
+
+              <button type="button" onClick={() => setActiveStream("stderr")}>
+                <ToolbarChip
+                  label="stderr"
+                  active={activeStream === "stderr"}
+                />
+              </button>
+
+              <ToolbarChip label="자동 스크롤" active={!isPaused} />
+              <ToolbarChip label="WS 예정" />
             </div>
 
-            <div className="max-h-[360px] space-y-2 overflow-y-auto bg-[#020617] p-4 font-mono text-sm">
-              {CONTAINER_LOG_PREVIEW.map((log, index) => (
-                <LogLine
-                  key={`${log.time}-${log.level}-${index}`}
-                  time={log.time}
-                  level={log.level}
-                  message={log.message}
-                />
-              ))}
+            <div
+              ref={terminalRef}
+              className="max-h-[380px] min-h-[280px] space-y-2 overflow-y-auto bg-[#020617] p-4 font-mono text-sm"
+            >
+              {filteredLogs.length === 0 ? (
+                <div className="rounded-xl border border-slate-800 bg-slate-950/80 px-4 py-3 text-sm text-slate-500">
+                  표시할 로그가 없습니다.
+                </div>
+              ) : (
+                filteredLogs.map((log, index) => (
+                  <MonitoringLogLine
+                    key={`${log.time}-${log.stream}-${index}`}
+                    time={log.time}
+                    stream={log.stream}
+                    message={log.message}
+                  />
+                ))
+              )}
             </div>
           </div>
         )}
       </CardContent>
     </Card>
+  )
+}
+
+function MonitoringLogLine({ time, stream, message }) {
+  const streamClassName =
+    stream === "stderr" ? "text-rose-300" : "text-cyan-300"
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-950/80 px-4 py-3">
+      <div className="flex flex-col gap-1 md:flex-row md:items-start md:gap-3">
+        <span className="shrink-0 text-xs text-slate-500">{time}</span>
+
+        <span className={`shrink-0 text-xs font-semibold ${streamClassName}`}>
+          {stream}
+        </span>
+
+        <p className="min-w-0 text-sm text-slate-300">{message}</p>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
@@ -2,14 +2,14 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import ToolbarChip from "@/components/dashboard/ToolbarChip"
-import { useMockContainerLogs } from "@/hooks/useMockContainerLogs"
+import { useContainerLogs } from "@/hooks/useContainerLogs"
 
 export default function MonitoringLogTerminal({ selectedContainer }) {
   const [activeStream, setActiveStream] = useState("all")
   const terminalRef = useRef(null)
 
   const { logs, isPaused, clearLogs, togglePause } =
-    useMockContainerLogs(selectedContainer)
+    useContainerLogs(selectedContainer)
 
   const filteredLogs = useMemo(() => {
     if (activeStream === "all") return logs

--- a/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
@@ -1,19 +1,25 @@
 import { useEffect, useMemo, useRef, useState } from "react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import ToolbarChip from "@/components/dashboard/ToolbarChip"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { useContainerLogs } from "@/hooks/useContainerLogs"
+import MonitoringLogHeader from "@/components/monitoring/MonitoringLogHeader"
+import MonitoringLogToolbar from "@/components/monitoring/MonitoringLogToolbar"
+import MonitoringLogBody from "@/components/monitoring/MonitoringLogBody"
 
 export default function MonitoringLogTerminal({ selectedContainer }) {
   const [activeStream, setActiveStream] = useState("all")
   const terminalRef = useRef(null)
 
-  const { logs, isPaused, clearLogs, togglePause } =
-    useContainerLogs(selectedContainer)
+  const {
+    logs,
+    isPaused,
+    clearLogs,
+    togglePause,
+    source,
+    connectionStatus,
+  } = useContainerLogs(selectedContainer)
 
   const filteredLogs = useMemo(() => {
     if (activeStream === "all") return logs
-
     return logs.filter((log) => log.stream === activeStream)
   }, [logs, activeStream])
 
@@ -26,32 +32,11 @@ export default function MonitoringLogTerminal({ selectedContainer }) {
   return (
     <Card className="rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">
       <CardHeader className="space-y-3">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <CardTitle className="text-lg font-semibold tracking-tight text-slate-50">
-              실시간 로그 터미널
-            </CardTitle>
-            <p className="mt-2 text-sm text-slate-400">
-              선택한 컨테이너의 stdout / stderr 로그를 터미널 형태로 표시합니다.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="w-fit rounded-full border border-slate-700 bg-slate-950 px-3 py-1 text-xs text-slate-400">
-              mock stream
-            </span>
-
-            <span
-              className={`w-fit rounded-full border px-3 py-1 text-xs ${
-                isPaused
-                  ? "border-amber-500/20 bg-amber-500/10 text-amber-300"
-                  : "border-emerald-500/20 bg-emerald-500/10 text-emerald-300"
-              }`}
-            >
-              {isPaused ? "paused" : "connected"}
-            </span>
-          </div>
-        </div>
+        <MonitoringLogHeader
+          source={source}
+          connectionStatus={connectionStatus}
+          isPaused={isPaused}
+        />
       </CardHeader>
 
       <CardContent>
@@ -61,109 +46,22 @@ export default function MonitoringLogTerminal({ selectedContainer }) {
           </div>
         ) : (
           <div className="overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/80">
-            <div className="flex flex-col gap-3 border-b border-slate-800 bg-slate-950/90 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-1.5">
-                  <span className="h-2.5 w-2.5 rounded-full bg-rose-400" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-amber-400" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
-                </div>
+            <MonitoringLogToolbar
+              selectedContainer={selectedContainer}
+              activeStream={activeStream}
+              onChangeStream={setActiveStream}
+              isPaused={isPaused}
+              onTogglePause={togglePause}
+              onClearLogs={clearLogs}
+            />
 
-                <div>
-                  <p className="text-sm font-medium text-slate-100">
-                    로그 스트림
-                  </p>
-                  <p className="text-xs text-slate-500">
-                    {selectedContainer.name} · {selectedContainer.image}
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex flex-wrap items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={togglePause}
-                  className="h-8 border-slate-700 bg-slate-950 px-3 text-xs text-slate-200 transition-all duration-150 hover:-translate-y-[1px] hover:bg-slate-800 hover:text-slate-50"
-                >
-                  {isPaused ? "재개" : "일시정지"}
-                </Button>
-
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={clearLogs}
-                  className="h-8 border-slate-700 bg-slate-950 px-3 text-xs text-slate-200 transition-all duration-150 hover:-translate-y-[1px] hover:bg-slate-800 hover:text-slate-50"
-                >
-                  지우기
-                </Button>
-              </div>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-2 border-b border-slate-800 bg-slate-950/60 px-4 py-3">
-              <button type="button" onClick={() => setActiveStream("all")}>
-                <ToolbarChip label="all" active={activeStream === "all"} />
-              </button>
-
-              <button type="button" onClick={() => setActiveStream("stdout")}>
-                <ToolbarChip
-                  label="stdout"
-                  active={activeStream === "stdout"}
-                />
-              </button>
-
-              <button type="button" onClick={() => setActiveStream("stderr")}>
-                <ToolbarChip
-                  label="stderr"
-                  active={activeStream === "stderr"}
-                />
-              </button>
-
-              <ToolbarChip label="자동 스크롤" active={!isPaused} />
-              <ToolbarChip label="WS 예정" />
-            </div>
-
-            <div
+            <MonitoringLogBody
               ref={terminalRef}
-              className="max-h-[380px] min-h-[280px] space-y-2 overflow-y-auto bg-[#020617] p-4 font-mono text-sm"
-            >
-              {filteredLogs.length === 0 ? (
-                <div className="rounded-xl border border-slate-800 bg-slate-950/80 px-4 py-3 text-sm text-slate-500">
-                  표시할 로그가 없습니다.
-                </div>
-              ) : (
-                filteredLogs.map((log, index) => (
-                  <MonitoringLogLine
-                    key={`${log.time}-${log.stream}-${index}`}
-                    time={log.time}
-                    stream={log.stream}
-                    message={log.message}
-                  />
-                ))
-              )}
-            </div>
+              logs={filteredLogs}
+            />
           </div>
         )}
       </CardContent>
     </Card>
-  )
-}
-
-function MonitoringLogLine({ time, stream, message }) {
-  const streamClassName =
-    stream === "stderr" ? "text-rose-300" : "text-cyan-300"
-
-  return (
-    <div className="rounded-xl border border-slate-800 bg-slate-950/80 px-4 py-3">
-      <div className="flex flex-col gap-1 md:flex-row md:items-start md:gap-3">
-        <span className="shrink-0 text-xs text-slate-500">{time}</span>
-
-        <span className={`shrink-0 text-xs font-semibold ${streamClassName}`}>
-          {stream}
-        </span>
-
-        <p className="min-w-0 text-sm text-slate-300">{message}</p>
-      </div>
-    </div>
   )
 }

--- a/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogTerminal.jsx
@@ -1,23 +1,25 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
-import { useContainerLogs } from "@/hooks/useContainerLogs"
 import MonitoringLogHeader from "@/components/monitoring/MonitoringLogHeader"
 import MonitoringLogToolbar from "@/components/monitoring/MonitoringLogToolbar"
 import MonitoringLogBody from "@/components/monitoring/MonitoringLogBody"
 
-export default function MonitoringLogTerminal({ selectedContainer }) {
+export default function MonitoringLogTerminal({
+  selectedContainer,
+  logsResult,
+}) {
   const [activeStream, setActiveStream] = useState("all")
   const terminalRef = useRef(null)
 
   const {
-    logs,
-    isPaused,
-    clearLogs,
-    togglePause,
-    source,
-    connectionStatus,
-    reconnect,
-  } = useContainerLogs(selectedContainer)
+    logs = [],
+    isPaused = false,
+    clearLogs = () => {},
+    togglePause = () => {},
+    source = "mock-fallback",
+    connectionStatus = "idle",
+    reconnect = () => {},
+  } = logsResult ?? {}
 
   const filteredLogs = useMemo(() => {
     if (activeStream === "all") return logs

--- a/frontend/src/components/monitoring/MonitoringLogToolbar.jsx
+++ b/frontend/src/components/monitoring/MonitoringLogToolbar.jsx
@@ -1,0 +1,69 @@
+import { Button } from "@/components/ui/button"
+import ToolbarChip from "@/components/dashboard/ToolbarChip"
+
+export default function MonitoringLogToolbar({
+  selectedContainer,
+  activeStream,
+  onChangeStream,
+  isPaused,
+  onTogglePause,
+  onClearLogs,
+}) {
+  return (
+    <>
+      <div className="flex flex-col gap-3 border-b border-slate-800 bg-slate-950/90 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1.5">
+            <span className="h-2.5 w-2.5 rounded-full bg-rose-400" />
+            <span className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+            <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
+          </div>
+
+          <div>
+            <p className="text-sm font-medium text-slate-100">로그 스트림</p>
+            <p className="text-xs text-slate-500">
+              {selectedContainer.name} · {selectedContainer.image}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onTogglePause}
+            className="h-8 border-slate-700 bg-slate-950 px-3 text-xs text-slate-200 transition-all duration-150 hover:-translate-y-[1px] hover:bg-slate-800 hover:text-slate-50"
+          >
+            {isPaused ? "재개" : "일시정지"}
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClearLogs}
+            className="h-8 border-slate-700 bg-slate-950 px-3 text-xs text-slate-200 transition-all duration-150 hover:-translate-y-[1px] hover:bg-slate-800 hover:text-slate-50"
+          >
+            지우기
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 border-b border-slate-800 bg-slate-950/60 px-4 py-3">
+        <button type="button" onClick={() => onChangeStream("all")}>
+          <ToolbarChip label="all" active={activeStream === "all"} />
+        </button>
+
+        <button type="button" onClick={() => onChangeStream("stdout")}>
+          <ToolbarChip label="stdout" active={activeStream === "stdout"} />
+        </button>
+
+        <button type="button" onClick={() => onChangeStream("stderr")}>
+          <ToolbarChip label="stderr" active={activeStream === "stderr"} />
+        </button>
+
+        <ToolbarChip label="자동 스크롤" active={!isPaused} />
+        <ToolbarChip label="auto fallback" active />
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/monitoring/MonitoringSourceBadge.jsx
+++ b/frontend/src/components/monitoring/MonitoringSourceBadge.jsx
@@ -1,0 +1,21 @@
+export default function MonitoringSourceBadge({ source }) {
+  const className =
+    source === "real"
+      ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-300"
+      : source === "mock-fallback"
+      ? "border-amber-500/20 bg-amber-500/10 text-amber-300"
+      : "border-slate-700 bg-slate-950 text-slate-400"
+
+  const label =
+    source === "real"
+      ? "REAL WS"
+      : source === "mock-fallback"
+      ? "MOCK FALLBACK"
+      : "MOCK"
+
+  return (
+    <span className={`w-fit rounded-full border px-3 py-1 text-xs ${className}`}>
+      {label}
+    </span>
+  )
+}

--- a/frontend/src/components/monitoring/MonitoringStatusCard.jsx
+++ b/frontend/src/components/monitoring/MonitoringStatusCard.jsx
@@ -1,0 +1,109 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import StatusBadge from "@/components/dashboard/StatusBadge"
+import InfoChip from "@/components/dashboard/InfoChip"
+
+export default function MonitoringStatusCard({ selectedContainer }) {
+  const containerId =
+    selectedContainer?.container_id ?? selectedContainer?.id ?? "-"
+
+  return (
+    <Card className="rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">
+      <CardHeader className="space-y-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <CardTitle className="text-lg font-semibold tracking-tight text-slate-50">
+              선택 컨테이너 정보
+            </CardTitle>
+            <p className="mt-2 text-sm text-slate-400">
+              현재 선택된 컨테이너와 WebSocket 연결 준비 상태를 표시합니다.
+            </p>
+          </div>
+
+          <span className="w-fit rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-300">
+            mock connected
+          </span>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {!selectedContainer ? (
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-5 text-sm text-slate-400">
+            컨테이너를 선택하면 상세 정보가 표시됩니다.
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/80">
+              <div className="border-b border-slate-800 bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.12),transparent_35%),linear-gradient(to_bottom,rgba(15,23,42,0.95),rgba(2,6,23,0.95))] p-5">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <span className="h-2.5 w-2.5 rounded-full bg-cyan-400 shadow-[0_0_10px_rgba(34,211,238,0.8)]" />
+                      <p className="text-xs font-medium uppercase tracking-[0.24em] text-cyan-400">
+                        Selected Container
+                      </p>
+                    </div>
+
+                    <div>
+                      <p className="truncate text-2xl font-semibold tracking-tight text-slate-50">
+                        {selectedContainer.name}
+                      </p>
+                      <p className="mt-1 truncate text-sm text-slate-400">
+                        {selectedContainer.image}
+                      </p>
+                    </div>
+                  </div>
+
+                  <StatusBadge status={selectedContainer.status} />
+                </div>
+              </div>
+
+              <div className="grid gap-3 p-4 md:grid-cols-3">
+                <InfoChip label="Container ID" value={String(containerId)} />
+                <InfoChip label="Image" value={selectedContainer.image} truncate />
+                <InfoChip
+                  label="Status"
+                  value={selectedContainer.status ?? "unknown"}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <ConnectionCard
+                label="Metrics WS"
+                endpoint="/ws/metrics/{container_id}"
+                status="Ready"
+              />
+              <ConnectionCard
+                label="Logs WS"
+                endpoint="/ws/logs/{container_id}"
+                status="Ready"
+              />
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ConnectionCard({ label, endpoint, status }) {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+          {label}
+        </p>
+
+        <span className="rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
+          {status}
+        </span>
+      </div>
+
+      <p className="mt-3 font-mono text-sm text-slate-300">{endpoint}</p>
+      <p className="mt-2 text-xs leading-5 text-slate-500">
+        현재는 mock UI 상태이며, 추후 WebSocket hook으로 교체할 수 있도록
+        영역을 분리했습니다.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/monitoring/MonitoringStatusCard.jsx
+++ b/frontend/src/components/monitoring/MonitoringStatusCard.jsx
@@ -1,10 +1,24 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import StatusBadge from "@/components/dashboard/StatusBadge"
 import InfoChip from "@/components/dashboard/InfoChip"
+import MonitoringConnectionBadge from "@/components/monitoring/MonitoringConnectionBadge"
+import MonitoringSourceBadge from "@/components/monitoring/MonitoringSourceBadge"
 
-export default function MonitoringStatusCard({ selectedContainer }) {
+export default function MonitoringStatusCard({
+  selectedContainer,
+  metricsResult,
+  logsResult,
+}) {
   const containerId =
     selectedContainer?.container_id ?? selectedContainer?.id ?? "-"
+
+  const metricsStatus = metricsResult?.connectionStatus ?? "idle"
+  const metricsSource = metricsResult?.source ?? "mock-fallback"
+
+  const logsStatus = logsResult?.connectionStatus ?? "idle"
+  const logsSource = logsResult?.source ?? "mock-fallback"
+
+  const overallStatus = getOverallStatus(metricsStatus, logsStatus)
 
   return (
     <Card className="rounded-2xl border-slate-800 bg-slate-900 text-slate-100 shadow-sm">
@@ -15,13 +29,11 @@ export default function MonitoringStatusCard({ selectedContainer }) {
               선택 컨테이너 정보
             </CardTitle>
             <p className="mt-2 text-sm text-slate-400">
-              현재 선택된 컨테이너와 WebSocket 연결 준비 상태를 표시합니다.
+              현재 선택된 컨테이너와 WebSocket 연결 상태를 표시합니다.
             </p>
           </div>
 
-          <span className="w-fit rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-300">
-            mock connected
-          </span>
+          <MonitoringConnectionBadge status={overallStatus} />
         </div>
       </CardHeader>
 
@@ -70,13 +82,15 @@ export default function MonitoringStatusCard({ selectedContainer }) {
             <div className="grid gap-4 md:grid-cols-2">
               <ConnectionCard
                 label="Metrics WS"
-                endpoint="/ws/metrics/{container_id}"
-                status="Ready"
+                endpoint="/container/ws/metrics/{container_id}"
+                status={metricsStatus}
+                source={metricsSource}
               />
               <ConnectionCard
                 label="Logs WS"
-                endpoint="/ws/logs/{container_id}"
-                status="Ready"
+                endpoint="/container/ws/logs/{container_id}"
+                status={logsStatus}
+                source={logsSource}
               />
             </div>
           </div>
@@ -86,7 +100,7 @@ export default function MonitoringStatusCard({ selectedContainer }) {
   )
 }
 
-function ConnectionCard({ label, endpoint, status }) {
+function ConnectionCard({ label, endpoint, status, source }) {
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-4">
       <div className="flex items-center justify-between gap-3">
@@ -94,16 +108,37 @@ function ConnectionCard({ label, endpoint, status }) {
           {label}
         </p>
 
-        <span className="rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
-          {status}
-        </span>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <MonitoringSourceBadge source={source} />
+          <MonitoringConnectionBadge status={status} />
+        </div>
       </div>
 
       <p className="mt-3 font-mono text-sm text-slate-300">{endpoint}</p>
       <p className="mt-2 text-xs leading-5 text-slate-500">
-        현재는 mock UI 상태이며, 추후 WebSocket hook으로 교체할 수 있도록
-        영역을 분리했습니다.
+        WebSocket 우선 연결 구조를 사용하며, 연결 실패 시 mock fallback으로
+        동작합니다.
       </p>
     </div>
   )
+}
+
+function getOverallStatus(metricsStatus, logsStatus) {
+  if (metricsStatus === "error" || logsStatus === "error") {
+    return "error"
+  }
+
+  if (metricsStatus === "fallback" || logsStatus === "fallback") {
+    return "fallback"
+  }
+
+  if (metricsStatus === "connecting" || logsStatus === "connecting") {
+    return "connecting"
+  }
+
+  if (metricsStatus === "connected" && logsStatus === "connected") {
+    return "connected"
+  }
+
+  return "idle"
 }

--- a/frontend/src/hooks/useContainerLogs.js
+++ b/frontend/src/hooks/useContainerLogs.js
@@ -1,0 +1,7 @@
+import { useMockContainerLogs } from "@/hooks/useMockContainerLogs"
+
+// 추후 WebSocket 확정 시 이 파일 내부만 교체하면 됩니다.
+// 현재는 mock logs hook을 그대로 반환합니다.
+export function useContainerLogs(selectedContainer) {
+  return useMockContainerLogs(selectedContainer)
+}

--- a/frontend/src/hooks/useContainerLogs.js
+++ b/frontend/src/hooks/useContainerLogs.js
@@ -17,6 +17,7 @@ export function useContainerLogs(selectedContainer) {
       ...mockResult,
       source: "mock",
       connectionStatus: "mock",
+      reconnect: realResult.reconnect,
     }
   }
 
@@ -43,5 +44,6 @@ export function useContainerLogs(selectedContainer) {
     source: "mock-fallback",
     connectionStatus: realResult.connectionStatus,
     realError: realResult.error,
+    reconnect: realResult.reconnect,
   }
 }

--- a/frontend/src/hooks/useContainerLogs.js
+++ b/frontend/src/hooks/useContainerLogs.js
@@ -1,7 +1,47 @@
 import { useMockContainerLogs } from "@/hooks/useMockContainerLogs"
+import { useContainerLogsWebSocket } from "@/hooks/useContainerLogsWebSocket"
 
-// 추후 WebSocket 확정 시 이 파일 내부만 교체하면 됩니다.
-// 현재는 mock logs hook을 그대로 반환합니다.
+const MONITORING_MODE =
+  import.meta.env.VITE_MONITORING_LOGS_MODE ?? "auto"
+
+// mode:
+// - "mock": 항상 mock 사용
+// - "real": 실제 WebSocket만 사용
+// - "auto": WebSocket 연결 성공 시 real, 실패/미연결 시 mock 사용
 export function useContainerLogs(selectedContainer) {
-  return useMockContainerLogs(selectedContainer)
+  const mockResult = useMockContainerLogs(selectedContainer)
+  const realResult = useContainerLogsWebSocket(selectedContainer)
+
+  if (MONITORING_MODE === "mock") {
+    return {
+      ...mockResult,
+      source: "mock",
+      connectionStatus: "mock",
+    }
+  }
+
+  if (MONITORING_MODE === "real") {
+    return {
+      ...realResult,
+      source: "real",
+    }
+  }
+
+  const shouldUseReal =
+    realResult.connectionStatus === "connected" &&
+    realResult.logs.length > 0
+
+  if (shouldUseReal) {
+    return {
+      ...realResult,
+      source: "real",
+    }
+  }
+
+  return {
+    ...mockResult,
+    source: "mock-fallback",
+    connectionStatus: realResult.connectionStatus,
+    realError: realResult.error,
+  }
 }

--- a/frontend/src/hooks/useContainerLogsWebSocket.js
+++ b/frontend/src/hooks/useContainerLogsWebSocket.js
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useState } from "react"
+import { buildWebSocketUrl } from "@/hooks/useWebSocketUrl"
+
+const MAX_LOG_LENGTH = 200
+
+function getContainerId(container) {
+  return container?.container_id ?? container?.id ?? null
+}
+
+function normalizeLogPayload(payload) {
+  return {
+    time: payload?.time ?? new Date(payload?.timestamp ?? Date.now()).toLocaleTimeString(),
+    stream: payload?.stream ?? "stdout",
+    message: payload?.message ?? "",
+  }
+}
+
+export function useContainerLogsWebSocket(selectedContainer) {
+  const [logs, setLogs] = useState([])
+  const [isPaused, setIsPaused] = useState(false)
+  const [connectionStatus, setConnectionStatus] = useState("idle")
+  const [error, setError] = useState(null)
+
+  const containerId = useMemo(() => {
+    return getContainerId(selectedContainer)
+  }, [selectedContainer])
+
+  useEffect(() => {
+    if (!containerId) {
+      setLogs([])
+      setIsPaused(false)
+      setConnectionStatus("idle")
+      setError(null)
+      return
+    }
+
+    let socket = null
+    let closedByCleanup = false
+
+    setLogs([])
+    setIsPaused(false)
+    setConnectionStatus("connecting")
+    setError(null)
+
+    try {
+      socket = new WebSocket(buildWebSocketUrl(`/ws/logs/${containerId}`))
+    } catch (e) {
+      setConnectionStatus("fallback")
+      setError(e)
+      return
+    }
+
+    socket.onopen = () => {
+      if (closedByCleanup) return
+      setConnectionStatus("connected")
+      setError(null)
+    }
+
+    socket.onmessage = (event) => {
+      if (closedByCleanup) return
+
+      try {
+        const payload = JSON.parse(event.data)
+        const normalizedLog = normalizeLogPayload(payload)
+
+        setLogs((currentLogs) => {
+          return [...currentLogs, normalizedLog].slice(-MAX_LOG_LENGTH)
+        })
+      } catch (e) {
+        setConnectionStatus("error")
+        setError(e)
+      }
+    }
+
+    socket.onerror = (event) => {
+      if (closedByCleanup) return
+      setConnectionStatus("fallback")
+      setError(event)
+    }
+
+    socket.onclose = () => {
+      if (closedByCleanup) return
+      setConnectionStatus("fallback")
+    }
+
+    return () => {
+      closedByCleanup = true
+
+      if (socket) {
+        socket.close()
+      }
+    }
+  }, [containerId])
+
+  function clearLogs() {
+    setLogs([])
+  }
+
+  function togglePause() {
+    setIsPaused((current) => !current)
+  }
+
+  const visibleLogs = isPaused ? logs : logs
+
+  return {
+    logs: visibleLogs,
+    isPaused,
+    connectionStatus,
+    error,
+    isMock: false,
+    isConnected: connectionStatus === "connected",
+    clearLogs,
+    togglePause,
+  }
+}

--- a/frontend/src/hooks/useContainerLogsWebSocket.js
+++ b/frontend/src/hooks/useContainerLogsWebSocket.js
@@ -46,7 +46,9 @@ export function useContainerLogsWebSocket(selectedContainer) {
     setError(null)
 
     try {
-      socket = new WebSocket(buildWebSocketUrl(`/ws/logs/${containerId}`))
+      socket = new WebSocket(
+        buildWebSocketUrl(`/container/ws/logs/${containerId}`)
+      )
     } catch (e) {
       setConnectionStatus("fallback")
       setError(e)

--- a/frontend/src/hooks/useContainerLogsWebSocket.js
+++ b/frontend/src/hooks/useContainerLogsWebSocket.js
@@ -9,7 +9,9 @@ function getContainerId(container) {
 
 function normalizeLogPayload(payload) {
   return {
-    time: payload?.time ?? new Date(payload?.timestamp ?? Date.now()).toLocaleTimeString(),
+    time:
+      payload?.time ??
+      new Date(payload?.timestamp ?? Date.now()).toLocaleTimeString(),
     stream: payload?.stream ?? "stdout",
     message: payload?.message ?? "",
   }
@@ -20,6 +22,7 @@ export function useContainerLogsWebSocket(selectedContainer) {
   const [isPaused, setIsPaused] = useState(false)
   const [connectionStatus, setConnectionStatus] = useState("idle")
   const [error, setError] = useState(null)
+  const [reconnectKey, setReconnectKey] = useState(0)
 
   const containerId = useMemo(() => {
     return getContainerId(selectedContainer)
@@ -90,7 +93,7 @@ export function useContainerLogsWebSocket(selectedContainer) {
         socket.close()
       }
     }
-  }, [containerId])
+  }, [containerId, reconnectKey])
 
   function clearLogs() {
     setLogs([])
@@ -100,10 +103,12 @@ export function useContainerLogsWebSocket(selectedContainer) {
     setIsPaused((current) => !current)
   }
 
-  const visibleLogs = isPaused ? logs : logs
+  function reconnect() {
+    setReconnectKey((current) => current + 1)
+  }
 
   return {
-    logs: visibleLogs,
+    logs,
     isPaused,
     connectionStatus,
     error,
@@ -111,5 +116,6 @@ export function useContainerLogsWebSocket(selectedContainer) {
     isConnected: connectionStatus === "connected",
     clearLogs,
     togglePause,
+    reconnect,
   }
 }

--- a/frontend/src/hooks/useContainerMetricHistory.js
+++ b/frontend/src/hooks/useContainerMetricHistory.js
@@ -17,6 +17,7 @@ export function useContainerMetricHistory(selectedContainer) {
       ...mockResult,
       source: "mock",
       connectionStatus: "mock",
+      reconnect: realResult.reconnect,
     }
   }
 
@@ -43,5 +44,6 @@ export function useContainerMetricHistory(selectedContainer) {
     source: "mock-fallback",
     connectionStatus: realResult.connectionStatus,
     realError: realResult.error,
+    reconnect: realResult.reconnect,
   }
 }

--- a/frontend/src/hooks/useContainerMetricHistory.js
+++ b/frontend/src/hooks/useContainerMetricHistory.js
@@ -1,7 +1,47 @@
 import { useMockContainerMetricHistory } from "@/hooks/useMockContainerMetricHistory"
+import { useContainerMetricsWebSocket } from "@/hooks/useContainerMetricsWebSocket"
 
-// 추후 WebSocket 확정 시 이 파일 내부만 교체하면 됩니다.
-// 현재는 mock history hook을 그대로 반환합니다.
+const MONITORING_MODE =
+  import.meta.env.VITE_MONITORING_METRICS_MODE ?? "auto"
+
+// mode:
+// - "mock": 항상 mock 사용
+// - "real": 실제 WebSocket만 사용
+// - "auto": WebSocket 연결 성공 시 real, 실패/미연결 시 mock 사용
 export function useContainerMetricHistory(selectedContainer) {
-  return useMockContainerMetricHistory(selectedContainer)
+  const mockResult = useMockContainerMetricHistory(selectedContainer)
+  const realResult = useContainerMetricsWebSocket(selectedContainer)
+
+  if (MONITORING_MODE === "mock") {
+    return {
+      ...mockResult,
+      source: "mock",
+      connectionStatus: "mock",
+    }
+  }
+
+  if (MONITORING_MODE === "real") {
+    return {
+      ...realResult,
+      source: "real",
+    }
+  }
+
+  const shouldUseReal =
+    realResult.connectionStatus === "connected" &&
+    realResult.history.length > 0
+
+  if (shouldUseReal) {
+    return {
+      ...realResult,
+      source: "real",
+    }
+  }
+
+  return {
+    ...mockResult,
+    source: "mock-fallback",
+    connectionStatus: realResult.connectionStatus,
+    realError: realResult.error,
+  }
 }

--- a/frontend/src/hooks/useContainerMetricHistory.js
+++ b/frontend/src/hooks/useContainerMetricHistory.js
@@ -1,0 +1,7 @@
+import { useMockContainerMetricHistory } from "@/hooks/useMockContainerMetricHistory"
+
+// 추후 WebSocket 확정 시 이 파일 내부만 교체하면 됩니다.
+// 현재는 mock history hook을 그대로 반환합니다.
+export function useContainerMetricHistory(selectedContainer) {
+  return useMockContainerMetricHistory(selectedContainer)
+}

--- a/frontend/src/hooks/useContainerMetricsWebSocket.js
+++ b/frontend/src/hooks/useContainerMetricsWebSocket.js
@@ -8,8 +8,9 @@ function getContainerId(container) {
 }
 
 function normalizeMetricPayload(payload, selectedContainer) {
-  const memoryUsageMb =
-    Number(payload?.memory_usage_mb ?? payload?.memory_mb ?? 0)
+  const memoryUsageMb = Number(
+    payload?.memory_usage_mb ?? payload?.memory_mb ?? 0
+  )
 
   const memoryLimitMb = Number(payload?.memory_limit_mb ?? 0)
 
@@ -24,7 +25,9 @@ function normalizeMetricPayload(payload, selectedContainer) {
     id: payload?.id ?? payload?.container_id ?? getContainerId(selectedContainer),
     name: payload?.name ?? selectedContainer?.name ?? "unknown-container",
     status: payload?.status ?? selectedContainer?.status ?? "unknown",
-    time: payload?.time ?? new Date(payload?.timestamp ?? Date.now()).toLocaleTimeString(),
+    time:
+      payload?.time ??
+      new Date(payload?.timestamp ?? Date.now()).toLocaleTimeString(),
     timestamp: payload?.timestamp ?? new Date().toISOString(),
     cpu_percent: clampMetric(Number(payload?.cpu_percent ?? 0)),
     memory_usage_mb: Number(memoryUsageMb.toFixed(1)),
@@ -43,6 +46,7 @@ export function useContainerMetricsWebSocket(selectedContainer) {
   const [latestMetric, setLatestMetric] = useState(null)
   const [connectionStatus, setConnectionStatus] = useState("idle")
   const [error, setError] = useState(null)
+  const [reconnectKey, setReconnectKey] = useState(0)
 
   const containerId = useMemo(() => {
     return getContainerId(selectedContainer)
@@ -114,7 +118,11 @@ export function useContainerMetricsWebSocket(selectedContainer) {
         socket.close()
       }
     }
-  }, [containerId, selectedContainer])
+  }, [containerId, selectedContainer, reconnectKey])
+
+  function reconnect() {
+    setReconnectKey((current) => current + 1)
+  }
 
   return {
     history,
@@ -123,5 +131,6 @@ export function useContainerMetricsWebSocket(selectedContainer) {
     error,
     isMock: false,
     isConnected: connectionStatus === "connected",
+    reconnect,
   }
 }

--- a/frontend/src/hooks/useContainerMetricsWebSocket.js
+++ b/frontend/src/hooks/useContainerMetricsWebSocket.js
@@ -70,7 +70,9 @@ export function useContainerMetricsWebSocket(selectedContainer) {
     setError(null)
 
     try {
-      socket = new WebSocket(buildWebSocketUrl(`/ws/metrics/${containerId}`))
+      socket = new WebSocket(
+        buildWebSocketUrl(`/container/ws/metrics/${containerId}`)
+      )
     } catch (e) {
       setConnectionStatus("fallback")
       setError(e)
@@ -88,11 +90,17 @@ export function useContainerMetricsWebSocket(selectedContainer) {
 
       try {
         const payload = JSON.parse(event.data)
-        const normalizedMetric = normalizeMetricPayload(payload, selectedContainer)
+        const normalizedMetric = normalizeMetricPayload(
+          payload,
+          selectedContainer
+        )
 
         setLatestMetric(normalizedMetric)
+
         setHistory((currentHistory) => {
-          return [...currentHistory, normalizedMetric].slice(-MAX_HISTORY_LENGTH)
+          return [...currentHistory, normalizedMetric].slice(
+            -MAX_HISTORY_LENGTH
+          )
         })
       } catch (e) {
         setConnectionStatus("error")

--- a/frontend/src/hooks/useContainerMetricsWebSocket.js
+++ b/frontend/src/hooks/useContainerMetricsWebSocket.js
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from "react"
+import { buildWebSocketUrl } from "@/hooks/useWebSocketUrl"
+
+const MAX_HISTORY_LENGTH = 16
+
+function getContainerId(container) {
+  return container?.container_id ?? container?.id ?? null
+}
+
+function normalizeMetricPayload(payload, selectedContainer) {
+  const memoryUsageMb =
+    Number(payload?.memory_usage_mb ?? payload?.memory_mb ?? 0)
+
+  const memoryLimitMb = Number(payload?.memory_limit_mb ?? 0)
+
+  const memoryPercent =
+    payload?.memory_percent != null
+      ? Number(payload.memory_percent)
+      : memoryLimitMb > 0
+      ? (memoryUsageMb / memoryLimitMb) * 100
+      : 0
+
+  return {
+    id: payload?.id ?? payload?.container_id ?? getContainerId(selectedContainer),
+    name: payload?.name ?? selectedContainer?.name ?? "unknown-container",
+    status: payload?.status ?? selectedContainer?.status ?? "unknown",
+    time: payload?.time ?? new Date(payload?.timestamp ?? Date.now()).toLocaleTimeString(),
+    timestamp: payload?.timestamp ?? new Date().toISOString(),
+    cpu_percent: clampMetric(Number(payload?.cpu_percent ?? 0)),
+    memory_usage_mb: Number(memoryUsageMb.toFixed(1)),
+    memory_limit_mb: Number(memoryLimitMb.toFixed(1)),
+    memory_percent: clampMetric(memoryPercent),
+  }
+}
+
+function clampMetric(value) {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, Number(value.toFixed(1))))
+}
+
+export function useContainerMetricsWebSocket(selectedContainer) {
+  const [history, setHistory] = useState([])
+  const [latestMetric, setLatestMetric] = useState(null)
+  const [connectionStatus, setConnectionStatus] = useState("idle")
+  const [error, setError] = useState(null)
+
+  const containerId = useMemo(() => {
+    return getContainerId(selectedContainer)
+  }, [selectedContainer])
+
+  useEffect(() => {
+    if (!containerId) {
+      setHistory([])
+      setLatestMetric(null)
+      setConnectionStatus("idle")
+      setError(null)
+      return
+    }
+
+    let socket = null
+    let closedByCleanup = false
+
+    setHistory([])
+    setLatestMetric(null)
+    setConnectionStatus("connecting")
+    setError(null)
+
+    try {
+      socket = new WebSocket(buildWebSocketUrl(`/ws/metrics/${containerId}`))
+    } catch (e) {
+      setConnectionStatus("fallback")
+      setError(e)
+      return
+    }
+
+    socket.onopen = () => {
+      if (closedByCleanup) return
+      setConnectionStatus("connected")
+      setError(null)
+    }
+
+    socket.onmessage = (event) => {
+      if (closedByCleanup) return
+
+      try {
+        const payload = JSON.parse(event.data)
+        const normalizedMetric = normalizeMetricPayload(payload, selectedContainer)
+
+        setLatestMetric(normalizedMetric)
+        setHistory((currentHistory) => {
+          return [...currentHistory, normalizedMetric].slice(-MAX_HISTORY_LENGTH)
+        })
+      } catch (e) {
+        setConnectionStatus("error")
+        setError(e)
+      }
+    }
+
+    socket.onerror = (event) => {
+      if (closedByCleanup) return
+      setConnectionStatus("fallback")
+      setError(event)
+    }
+
+    socket.onclose = () => {
+      if (closedByCleanup) return
+      setConnectionStatus("fallback")
+    }
+
+    return () => {
+      closedByCleanup = true
+
+      if (socket) {
+        socket.close()
+      }
+    }
+  }, [containerId, selectedContainer])
+
+  return {
+    history,
+    latestMetric,
+    connectionStatus,
+    error,
+    isMock: false,
+    isConnected: connectionStatus === "connected",
+  }
+}

--- a/frontend/src/hooks/useMockContainerLogs.js
+++ b/frontend/src/hooks/useMockContainerLogs.js
@@ -1,0 +1,101 @@
+import { useEffect, useMemo, useState } from "react"
+import { MONITORING_LOG_TEMPLATES } from "@/mocks/data/monitoringLogs"
+
+const MAX_LOG_LENGTH = 40
+const INITIAL_LOG_LENGTH = 10
+
+function getContainerKey(container) {
+  return container?.container_id ?? container?.id ?? "unknown"
+}
+
+function getCurrentTime() {
+  return new Date().toLocaleTimeString()
+}
+
+function createLog(container, index) {
+  const containerName = container?.name ?? "unknown-container"
+  const template =
+    MONITORING_LOG_TEMPLATES[index % MONITORING_LOG_TEMPLATES.length]
+
+  return {
+    time: getCurrentTime(),
+    stream: template.stream,
+    message: `[${containerName}] ${template.message}`,
+  }
+}
+
+function createInitialLogs(container) {
+  return Array.from({ length: INITIAL_LOG_LENGTH }, (_, index) => {
+    const containerName = container?.name ?? "unknown-container"
+    const template =
+      MONITORING_LOG_TEMPLATES[index % MONITORING_LOG_TEMPLATES.length]
+
+    return {
+      time: new Date(Date.now() - (INITIAL_LOG_LENGTH - index) * 2000)
+        .toLocaleTimeString(),
+      stream: template.stream,
+      message: `[${containerName}] ${template.message}`,
+    }
+  })
+}
+
+export function useMockContainerLogs(selectedContainer) {
+  const [logs, setLogs] = useState([])
+  const [tick, setTick] = useState(0)
+  const [isPaused, setIsPaused] = useState(false)
+
+  const containerKey = useMemo(() => {
+    return getContainerKey(selectedContainer)
+  }, [selectedContainer])
+
+  useEffect(() => {
+    if (!selectedContainer) {
+      setLogs([])
+      setTick(0)
+      setIsPaused(false)
+      return
+    }
+
+    setLogs(createInitialLogs(selectedContainer))
+    setTick(0)
+    setIsPaused(false)
+  }, [selectedContainer, containerKey])
+
+  useEffect(() => {
+    if (!selectedContainer || isPaused) return
+
+    const intervalId = window.setInterval(() => {
+      setTick((currentTick) => {
+        const nextTick = currentTick + 1
+
+        setLogs((currentLogs) => {
+          const nextLog = createLog(selectedContainer, nextTick)
+
+          return [...currentLogs, nextLog].slice(-MAX_LOG_LENGTH)
+        })
+
+        return nextTick
+      })
+    }, 2200)
+
+    return () => {
+      window.clearInterval(intervalId)
+    }
+  }, [selectedContainer, containerKey, isPaused])
+
+  function clearLogs() {
+    setLogs([])
+  }
+
+  function togglePause() {
+    setIsPaused((current) => !current)
+  }
+
+  return {
+    logs,
+    isPaused,
+    isMock: true,
+    clearLogs,
+    togglePause,
+  }
+}

--- a/frontend/src/hooks/useMockContainerMetricHistory.js
+++ b/frontend/src/hooks/useMockContainerMetricHistory.js
@@ -1,0 +1,102 @@
+import { useEffect, useMemo, useState } from "react"
+
+const MAX_HISTORY_LENGTH = 16
+
+function getContainerKey(container) {
+  return container?.container_id ?? container?.id ?? "unknown"
+}
+
+function createInitialHistory(container) {
+  const containerKey = getContainerKey(container)
+  const now = Date.now()
+
+  return Array.from({ length: MAX_HISTORY_LENGTH }, (_, index) => {
+    const offset = MAX_HISTORY_LENGTH - index
+    const tick = index + containerKey.length
+
+    const cpuPercent = 28 + Math.sin(tick / 2) * 14 + (tick % 4) * 2.2
+    const memoryPercent = 34 + Math.cos(tick / 3) * 11 + (tick % 5) * 1.8
+    const memoryLimitMb = 2048
+    const memoryUsageMb = (memoryLimitMb * memoryPercent) / 100
+
+    return {
+      time: new Date(now - offset * 3000).toLocaleTimeString(),
+      cpu_percent: clampMetric(cpuPercent),
+      memory_percent: clampMetric(memoryPercent),
+      memory_usage_mb: Number(memoryUsageMb.toFixed(1)),
+      memory_limit_mb: memoryLimitMb,
+    }
+  })
+}
+
+function createNextMetric(container, tick) {
+  const containerKey = getContainerKey(container)
+  const base = tick + containerKey.length
+
+  const cpuPercent = 30 + Math.sin(base / 2) * 18 + (base % 4) * 2
+  const memoryPercent = 36 + Math.cos(base / 3) * 12 + (base % 5) * 1.6
+  const memoryLimitMb = 2048
+  const memoryUsageMb = (memoryLimitMb * memoryPercent) / 100
+
+  return {
+    time: new Date().toLocaleTimeString(),
+    cpu_percent: clampMetric(cpuPercent),
+    memory_percent: clampMetric(memoryPercent),
+    memory_usage_mb: Number(memoryUsageMb.toFixed(1)),
+    memory_limit_mb: memoryLimitMb,
+  }
+}
+
+function clampMetric(value) {
+  return Math.max(0, Math.min(100, Number(value.toFixed(1))))
+}
+
+export function useMockContainerMetricHistory(selectedContainer) {
+  const [tick, setTick] = useState(0)
+  const [history, setHistory] = useState([])
+
+  const containerKey = useMemo(() => {
+    return getContainerKey(selectedContainer)
+  }, [selectedContainer])
+
+  useEffect(() => {
+    if (!selectedContainer) {
+      setHistory([])
+      setTick(0)
+      return
+    }
+
+    setHistory(createInitialHistory(selectedContainer))
+    setTick(0)
+  }, [selectedContainer, containerKey])
+
+  useEffect(() => {
+    if (!selectedContainer) return
+
+    const intervalId = window.setInterval(() => {
+      setTick((currentTick) => {
+        const nextTick = currentTick + 1
+
+        setHistory((currentHistory) => {
+          const nextMetric = createNextMetric(selectedContainer, nextTick)
+
+          return [...currentHistory, nextMetric].slice(-MAX_HISTORY_LENGTH)
+        })
+
+        return nextTick
+      })
+    }, 3000)
+
+    return () => {
+      window.clearInterval(intervalId)
+    }
+  }, [selectedContainer, containerKey])
+
+  const latestMetric = history.at(-1) ?? null
+
+  return {
+    history,
+    latestMetric,
+    isMock: true,
+  }
+}

--- a/frontend/src/hooks/useWebSocketUrl.js
+++ b/frontend/src/hooks/useWebSocketUrl.js
@@ -1,0 +1,44 @@
+function toWebSocketProtocol(protocol) {
+  return protocol === "https:" ? "wss:" : "ws:"
+}
+
+function removeTrailingSlash(value) {
+  return String(value ?? "").replace(/\/$/, "")
+}
+
+function convertHttpUrlToWsUrl(url) {
+  if (!url) return ""
+
+  return removeTrailingSlash(url)
+    .replace(/^https:\/\//, "wss://")
+    .replace(/^http:\/\//, "ws://")
+}
+
+export function getWebSocketBaseUrl() {
+  const explicitWsBaseUrl = import.meta.env.VITE_WS_BASE_URL
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
+
+  if (explicitWsBaseUrl) {
+    return removeTrailingSlash(explicitWsBaseUrl)
+  }
+
+  if (apiBaseUrl) {
+    return convertHttpUrlToWsUrl(apiBaseUrl)
+  }
+
+  const { protocol, hostname } = window.location
+
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return "ws://localhost:8000"
+  }
+
+  return `${toWebSocketProtocol(protocol)}//${window.location.host}`
+}
+
+export function buildWebSocketUrl(path) {
+  const normalizedPath = String(path ?? "").startsWith("/")
+    ? path
+    : `/${path}`
+
+  return `${getWebSocketBaseUrl()}${normalizedPath}`
+}

--- a/frontend/src/hooks/useWebSocketUrl.js
+++ b/frontend/src/hooks/useWebSocketUrl.js
@@ -16,7 +16,8 @@ function convertHttpUrlToWsUrl(url) {
 
 export function getWebSocketBaseUrl() {
   const explicitWsBaseUrl = import.meta.env.VITE_WS_BASE_URL
-  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
+  const apiBaseUrl =
+    import.meta.env.VITE_API_BASE_URL ?? import.meta.env.VITE_API_URL
 
   if (explicitWsBaseUrl) {
     return removeTrailingSlash(explicitWsBaseUrl)

--- a/frontend/src/layouts/MainLayout.jsx
+++ b/frontend/src/layouts/MainLayout.jsx
@@ -1,14 +1,10 @@
 import SidebarNav from "@/components/layout/SidebarNav"
 
-export default function MainLayout({
-  children,
-  activeMenu = "dashboard",
-  onChangeMenu,
-}) {
+export default function MainLayout({ children }) {
   return (
     <div className="min-h-screen bg-slate-950 px-6 py-8 text-slate-100">
       <div className="mx-auto flex max-w-[1600px] gap-7 xl:gap-8">
-        <SidebarNav activeMenu={activeMenu} onChangeMenu={onChangeMenu} />
+        <SidebarNav />
 
         <main className="min-w-0 flex-1">{children}</main>
       </div>

--- a/frontend/src/mocks/data/monitoringLogs.js
+++ b/frontend/src/mocks/data/monitoringLogs.js
@@ -1,0 +1,42 @@
+export const MONITORING_LOG_TEMPLATES = [
+  {
+    stream: "stdout",
+    message: "server started",
+  },
+  {
+    stream: "stdout",
+    message: "health check endpoint registered",
+  },
+  {
+    stream: "stdout",
+    message: "metrics collector initialized",
+  },
+  {
+    stream: "stdout",
+    message: "request handled successfully",
+  },
+  {
+    stream: "stderr",
+    message: "temporary upstream timeout detected",
+  },
+  {
+    stream: "stdout",
+    message: "connection recovered",
+  },
+  {
+    stream: "stdout",
+    message: "container resource snapshot emitted",
+  },
+  {
+    stream: "stderr",
+    message: "retrying dependent service connection",
+  },
+  {
+    stream: "stdout",
+    message: "log stream heartbeat received",
+  },
+  {
+    stream: "stdout",
+    message: "application ready to accept requests",
+  },
+]

--- a/frontend/src/pages/Monitoring.jsx
+++ b/frontend/src/pages/Monitoring.jsx
@@ -1,0 +1,111 @@
+import { useMemo, useState } from "react"
+import MainLayout from "@/layouts/MainLayout"
+import { useContainers } from "@/hooks/useContainers"
+import MonitoringContainerList from "@/components/monitoring/MonitoringContainerList"
+import MonitoringChartPanel from "@/components/monitoring/MonitoringChartPanel"
+import MonitoringStatusCard from "@/components/monitoring/MonitoringStatusCard"
+import MonitoringLogTerminal from "@/components/monitoring/MonitoringLogTerminal"
+
+export default function Monitoring() {
+  const {
+    data: containerData,
+    isLoading: isContainersLoading,
+    isError: isContainersError,
+    error: containersError,
+  } = useContainers()
+
+  const containers = useMemo(() => {
+    return Array.isArray(containerData)
+      ? containerData
+      : containerData?.containers ?? []
+  }, [containerData])
+
+  const [selectedContainerId, setSelectedContainerId] = useState(null)
+
+  const selectedContainer = useMemo(() => {
+    if (containers.length === 0) return null
+
+    if (!selectedContainerId) {
+      return containers[0]
+    }
+
+    return (
+      containers.find((container) => {
+        const currentId = container.container_id ?? container.id
+        return currentId === selectedContainerId
+      }) ?? containers[0]
+    )
+  }, [containers, selectedContainerId])
+
+  function handleSelectContainer(container) {
+    const currentId = container.container_id ?? container.id
+    setSelectedContainerId(currentId)
+  }
+
+  return (
+    <MainLayout>
+      <div className="space-y-7">
+        <header className="overflow-hidden rounded-3xl border border-slate-800 bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.14),transparent_28%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.08),transparent_24%),linear-gradient(to_bottom,rgba(15,23,42,0.96),rgba(2,6,23,0.96))] shadow-[0_20px_60px_rgba(2,6,23,0.32)]">
+          <div className="p-7 xl:p-9">
+            <div className="flex flex-wrap items-center gap-3">
+              <p className="text-xs font-medium uppercase tracking-[0.28em] text-cyan-400">
+                Detailed Monitoring
+              </p>
+
+              <span className="inline-flex items-center gap-2 rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
+                <span className="h-2 w-2 rounded-full bg-cyan-400 shadow-[0_0_10px_rgba(34,211,238,0.8)]" />
+                Mock preview
+              </span>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              <h1 className="text-4xl font-semibold tracking-tight text-slate-50 xl:text-[42px]">
+                상세 모니터링
+              </h1>
+
+              <p className="max-w-3xl text-sm leading-7 text-slate-400 xl:text-[15px]">
+                선택한 컨테이너의 CPU, Memory 변화와 로그 스트림을 한 화면에서
+                확인합니다. 현재는 mock 데이터를 기반으로 UI 구조를 먼저 구성하고,
+                추후 WebSocket 연결로 전환할 수 있도록 영역을 분리합니다.
+              </p>
+            </div>
+
+            <div className="mt-6 flex flex-wrap items-center gap-3">
+              <HeaderMetaChip label="Metrics" value="/ws/metrics/{container_id}" />
+              <HeaderMetaChip label="Logs" value="/ws/logs/{container_id}" />
+              <HeaderMetaChip label="Mode" value="Mock UI Preview" />
+            </div>
+          </div>
+        </header>
+
+        <div className="grid gap-7 xl:grid-cols-[360px_minmax(0,1fr)]">
+          <MonitoringContainerList
+            containers={containers}
+            isLoading={isContainersLoading}
+            isError={isContainersError}
+            error={containersError}
+            selectedContainer={selectedContainer}
+            onSelectContainer={handleSelectContainer}
+          />
+
+          <section className="space-y-7">
+            <MonitoringChartPanel selectedContainer={selectedContainer} />
+
+            <MonitoringStatusCard selectedContainer={selectedContainer} />
+
+            <MonitoringLogTerminal selectedContainer={selectedContainer} />
+          </section>
+        </div>
+      </div>
+    </MainLayout>
+  )
+}
+
+function HeaderMetaChip({ label, value }) {
+  return (
+    <div className="rounded-full border border-slate-800 bg-slate-950/50 px-3 py-2 text-xs text-slate-400 backdrop-blur-sm">
+      <span className="mr-2 text-slate-500">{label}</span>
+      <span className="text-slate-300">{value}</span>
+    </div>
+  )
+}

--- a/frontend/src/pages/Monitoring.jsx
+++ b/frontend/src/pages/Monitoring.jsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react"
 import MainLayout from "@/layouts/MainLayout"
 import { useContainers } from "@/hooks/useContainers"
+import { useContainerMetricHistory } from "@/hooks/useContainerMetricHistory"
+import { useContainerLogs } from "@/hooks/useContainerLogs"
 import MonitoringContainerList from "@/components/monitoring/MonitoringContainerList"
 import MonitoringChartPanel from "@/components/monitoring/MonitoringChartPanel"
 import MonitoringStatusCard from "@/components/monitoring/MonitoringStatusCard"
@@ -37,6 +39,9 @@ export default function Monitoring() {
     )
   }, [containers, selectedContainerId])
 
+  const metricsResult = useContainerMetricHistory(selectedContainer)
+  const logsResult = useContainerLogs(selectedContainer)
+
   function handleSelectContainer(container) {
     const currentId = container.container_id ?? container.id
     setSelectedContainerId(currentId)
@@ -54,7 +59,7 @@ export default function Monitoring() {
 
               <span className="inline-flex items-center gap-2 rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-300">
                 <span className="h-2 w-2 rounded-full bg-cyan-400 shadow-[0_0_10px_rgba(34,211,238,0.8)]" />
-                Mock preview
+                WebSocket Ready
               </span>
             </div>
 
@@ -65,15 +70,21 @@ export default function Monitoring() {
 
               <p className="max-w-3xl text-sm leading-7 text-slate-400 xl:text-[15px]">
                 선택한 컨테이너의 CPU, Memory 변화와 로그 스트림을 한 화면에서
-                확인합니다. 현재는 mock 데이터를 기반으로 UI 구조를 먼저 구성하고,
-                추후 WebSocket 연결로 전환할 수 있도록 영역을 분리합니다.
+                확인합니다. WebSocket 우선 연결 구조를 적용했으며, 연결 실패 시
+                mock fallback으로 동작합니다.
               </p>
             </div>
 
             <div className="mt-6 flex flex-wrap items-center gap-3">
-              <HeaderMetaChip label="Metrics" value="/ws/metrics/{container_id}" />
-              <HeaderMetaChip label="Logs" value="/ws/logs/{container_id}" />
-              <HeaderMetaChip label="Mode" value="Mock UI Preview" />
+              <HeaderMetaChip
+                label="Metrics"
+                value="/container/ws/metrics/{container_id}"
+              />
+              <HeaderMetaChip
+                label="Logs"
+                value="/container/ws/logs/{container_id}"
+              />
+              <HeaderMetaChip label="Mode" value="Real WS + Mock Fallback" />
             </div>
           </div>
         </header>
@@ -89,11 +100,21 @@ export default function Monitoring() {
           />
 
           <section className="space-y-7">
-            <MonitoringChartPanel selectedContainer={selectedContainer} />
+            <MonitoringChartPanel
+              selectedContainer={selectedContainer}
+              metricsResult={metricsResult}
+            />
 
-            <MonitoringStatusCard selectedContainer={selectedContainer} />
+            <MonitoringStatusCard
+              selectedContainer={selectedContainer}
+              metricsResult={metricsResult}
+              logsResult={logsResult}
+            />
 
-            <MonitoringLogTerminal selectedContainer={selectedContainer} />
+            <MonitoringLogTerminal
+              selectedContainer={selectedContainer}
+              logsResult={logsResult}
+            />
           </section>
         </div>
       </div>

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom"
 import Login from "@/pages/Login"
 import Dashboard from "@/pages/Dashboard"
+import Monitoring from "@/pages/Monitoring"
 
 export default function Router() {
   return (
@@ -8,6 +9,7 @@ export default function Router() {
       <Routes>
         <Route path="/" element={<Login />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/monitoring" element={<Monitoring />} />
       </Routes>
     </BrowserRouter>
   )


### PR DESCRIPTION
## 연관 이슈
#76 

## 작업 내용
1. 상세 모니터링 페이지 추가
- `/monitoring` 라우트 신규 추가
- Dashboard와 동일한 디자인 톤으로 페이지 구성
- 좌측 컨테이너 목록 / 우측 상세 패널 구조 적용
2. SidebarNav 라우팅 연결
- Sidebar 메뉴 클릭 시 실제 페이지 이동 가능하도록 수정
- Monitoring 메뉴 신규 추가
- Logs 단독 메뉴 제거 (상세 모니터링 내부 통합)
3. Metrics UI 추가
- CPU / Memory Recharts LineChart 구현
- mock 기반 변동 데이터 적용
4. Logs UI 추가
- 로그 터미널 UI
- stdout / stderr / all 필터 기능
- pause / resume / clear 기능
- mock stream 기반 로그 append 구조
5. 구조 개선 (WS 대비)
- 상세 모니터링 페이지 WebSocket 연결 대비 구조 보완
- WS 연결 실패 시 mock fallback 유지하도록 개선
- Metrics / Logs 영역별 WS 재연결 버튼 추가
- 로그 터미널 컴포넌트 구조화 및 유지보수성 개선
- 실제 WS 엔드포인트 구현 시 연동 가능한 형태로 프론트 준비

## 참고
<img width="1265" height="692" alt="DetailMonitoring_mock1" src="https://github.com/user-attachments/assets/30a8ab56-f2d2-4361-98f6-8670e229ac46" />
라인 차트와 상단 화면

<img width="1256" height="518" alt="DetailMonitoring_mock2" src="https://github.com/user-attachments/assets/082f7b51-16e5-4102-95b4-e7a9269d946f" />
선택된 컨테이너 정보 표시

<img width="1259" height="683" alt="DetailMonitoring_mock3" src="https://github.com/user-attachments/assets/ba0b9128-fcba-4508-a238-34819b4bfc5e" />
선택된 컨테이너 로그 표시

https://github.com/user-attachments/assets/d1937203-8aee-4432-baa7-6c6bc25cc677


