### PR TITLE
fix: 통합 테스트 fallback 설정 정리

### DIFF
--- a/frontend/src/api/containerApi.js
+++ b/frontend/src/api/containerApi.js
@@ -1,5 +1,3 @@
-// src/api/containerApi.js
-
 import { api } from "./client"
 import axios from "axios"
 import { mockContainers } from "@/mocks/data/containers"

--- a/frontend/src/hooks/useContainerLogs.js
+++ b/frontend/src/hooks/useContainerLogs.js
@@ -4,22 +4,23 @@ import { useContainerLogsWebSocket } from "@/hooks/useContainerLogsWebSocket"
 const MONITORING_MODE =
   import.meta.env.VITE_MONITORING_LOGS_MODE ?? "auto"
 
-// mode:
-// - "mock": 항상 mock 사용
-// - "real": 실제 WebSocket만 사용
-// - "auto": WebSocket 연결 성공 시 real, 실패/미연결 시 mock 사용
-export function useContainerLogs(selectedContainer) {
+// mock 전용 hook 결과를 반환합니다.
+function useMockLogsOnly(selectedContainer) {
+  const mockResult = useMockContainerLogs(selectedContainer)
+
+  return {
+    ...mockResult,
+    source: "mock",
+    connectionStatus: "mock",
+    realError: null,
+    reconnect: () => {},
+  }
+}
+
+// real 또는 auto 모드에서 logs WebSocket과 mock fallback을 함께 관리합니다.
+function useAutoLogs(selectedContainer) {
   const mockResult = useMockContainerLogs(selectedContainer)
   const realResult = useContainerLogsWebSocket(selectedContainer)
-
-  if (MONITORING_MODE === "mock") {
-    return {
-      ...mockResult,
-      source: "mock",
-      connectionStatus: "mock",
-      reconnect: realResult.reconnect,
-    }
-  }
 
   if (MONITORING_MODE === "real") {
     return {
@@ -46,4 +47,13 @@ export function useContainerLogs(selectedContainer) {
     realError: realResult.error,
     reconnect: realResult.reconnect,
   }
+}
+
+// 로그 모드에 따라 mock-only 또는 real/auto 로그 처리를 선택합니다.
+export function useContainerLogs(selectedContainer) {
+  if (MONITORING_MODE === "mock") {
+    return useMockLogsOnly(selectedContainer)
+  }
+
+  return useAutoLogs(selectedContainer)
 }

--- a/frontend/src/hooks/useContainerLogs.js
+++ b/frontend/src/hooks/useContainerLogs.js
@@ -43,7 +43,8 @@ function useAutoLogs(selectedContainer) {
   return {
     ...mockResult,
     source: "mock-fallback",
-    connectionStatus: realResult.connectionStatus,
+    connectionStatus: "fallback",
+    realConnectionStatus: realResult.connectionStatus,
     realError: realResult.error,
     reconnect: realResult.reconnect,
   }

--- a/frontend/src/hooks/useContainerMetricHistory.js
+++ b/frontend/src/hooks/useContainerMetricHistory.js
@@ -42,7 +42,8 @@ export function useContainerMetricHistory(selectedContainer) {
   return {
     ...mockResult,
     source: "mock-fallback",
-    connectionStatus: realResult.connectionStatus,
+    connectionStatus: "fallback",
+    realConnectionStatus: realResult.connectionStatus,
     realError: realResult.error,
     reconnect: realResult.reconnect,
   }

--- a/frontend/src/hooks/useMockContainerLogs.js
+++ b/frontend/src/hooks/useMockContainerLogs.js
@@ -91,8 +91,15 @@ export function useMockContainerLogs(selectedContainer) {
     setIsPaused((current) => !current)
   }
 
+  const fallbackLogs = useMemo(() => {
+    if (!selectedContainer) return []
+    return createInitialLogs(selectedContainer)
+  }, [selectedContainer, containerKey])
+
+  const displayLogs = logs.length > 0 ? logs : fallbackLogs
+
   return {
-    logs,
+    logs: displayLogs,
     isPaused,
     isMock: true,
     clearLogs,

--- a/frontend/src/hooks/useMockContainerMetricHistory.js
+++ b/frontend/src/hooks/useMockContainerMetricHistory.js
@@ -92,10 +92,16 @@ export function useMockContainerMetricHistory(selectedContainer) {
     }
   }, [selectedContainer, containerKey])
 
-  const latestMetric = history.at(-1) ?? null
+  const fallbackHistory = useMemo(() => {
+    if (!selectedContainer) return []
+    return createInitialHistory(selectedContainer)
+  }, [selectedContainer, containerKey])
+
+  const displayHistory = history.length > 0 ? history : fallbackHistory
+  const latestMetric = displayHistory.at(-1) ?? null
 
   return {
-    history,
+    history: displayHistory,
     latestMetric,
     isMock: true,
   }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -7,7 +7,10 @@ import "./index.css"
 const queryClient = new QueryClient()
 
 async function enableMocking() {
-  if (import.meta.env.DEV) {
+  if (
+    import.meta.env.DEV &&
+    import.meta.env.VITE_ENABLE_MSW === "true"
+  ) {
     const { worker } = await import("./mocks/browser")
 
     await worker.start({


### PR DESCRIPTION
## 연관 이슈
#82 

## 작업 내용
통합 테스트를 위해 프론트의 mock / real API 전환 설정을 정리하겠습니다.
- `main.jsx`
  - 개발 환경에서 MSW가 항상 실행되지 않도록 수정
  - `VITE_ENABLE_MSW=true`일 때만 MSW 실행

- `containerApi.js`
  - 컨테이너 목록 조회 시 `/container/` 우선 호출
  - 실패 시 `/container/test` fallback
  - stats mock은 `VITE_USE_STATS_MOCK=true`일 때만 사용
  - Compose 실행 API `POST /container/compose/up` 유지

- `useContainerLogs.js`
  - logs를 mock 고정이 아닌 auto fallback 구조로 정리
  - real logs WS 연결 및 로그 수신 시 real 사용
  - 연결 전/실패/미수신 상태에서는 mock fallback 사용
 
## 참고
본 PR은 아래 PR을 기반으로 생성된 stacked PR입니다.
#79 
따라서 #79 가 먼저 merge 된 이후 본 PR을 merge 해야합니다.