### PR TITLE
feat: Compose Editor 동기화 UX 및 구조 정리

### DIFF
--- a/frontend/src/features/compose/components/ComposeEditorHeader.jsx
+++ b/frontend/src/features/compose/components/ComposeEditorHeader.jsx
@@ -1,0 +1,13 @@
+// Compose Editor 페이지의 제목과 설명을 렌더링합니다.
+export default function ComposeEditorHeader() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-slate-100">
+        Compose Editor
+      </h1>
+      <p className="mt-1 text-sm text-slate-500">
+        Docker Compose YAML을 옵션 또는 코드로 작성하고 배포합니다.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/features/compose/components/ComposeEditorToolbar.jsx
+++ b/frontend/src/features/compose/components/ComposeEditorToolbar.jsx
@@ -1,0 +1,21 @@
+// Compose 실행 버튼과 배포 진행 상태를 렌더링합니다.
+import { Button } from "@/components/ui/button"
+
+export default function ComposeEditorToolbar({
+  isDeploying,
+  onDeployCompose,
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button onClick={onDeployCompose} disabled={isDeploying}>
+        {isDeploying ? "배포 요청 중..." : "Compose 실행"}
+      </Button>
+
+      {isDeploying && (
+        <p className="text-sm text-slate-400">
+          백엔드로 Compose YAML을 전송하고 있습니다.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/compose/components/ComposeFeedbackMessage.jsx
+++ b/frontend/src/features/compose/components/ComposeFeedbackMessage.jsx
@@ -1,0 +1,19 @@
+// Compose Editor의 에러 및 성공 메시지를 렌더링합니다.
+export default function ComposeFeedbackMessage({
+  errorMessage,
+  successMessage,
+}) {
+  if (!errorMessage && !successMessage) {
+    return null
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-950/70 px-4 py-3">
+      {errorMessage && <p className="text-sm text-red-400">{errorMessage}</p>}
+
+      {successMessage && (
+        <p className="text-sm text-cyan-300">{successMessage}</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/compose/components/ComposeSyncControl.jsx
+++ b/frontend/src/features/compose/components/ComposeSyncControl.jsx
@@ -1,0 +1,22 @@
+// Options와 YAML Editor 사이의 수동 동기화 버튼을 렌더링합니다.
+import { Repeat2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+
+export default function ComposeSyncControl({ label, onSync }) {
+  return (
+    <div className="flex items-center justify-center">
+      <div className="flex w-full items-center justify-center rounded-2xl border border-slate-800 bg-slate-950/70 p-3 xl:w-auto">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onSync}
+          className="w-full border-slate-700 bg-slate-950 text-base font-semibold text-slate-200 hover:bg-slate-800 hover:text-slate-50 xl:w-auto"
+        >
+          <Repeat2 className="mr-2 size-5" />
+          {label}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/compose/components/ComposeYamlEditorPanel.jsx
+++ b/frontend/src/features/compose/components/ComposeYamlEditorPanel.jsx
@@ -1,0 +1,31 @@
+// Monaco 기반 YAML Editor 패널을 렌더링합니다.
+import Editor from "@monaco-editor/react"
+
+import { Card } from "@/components/ui/card"
+
+export default function ComposeYamlEditorPanel({ yamlText, onChange }) {
+  return (
+    <Card className="overflow-hidden border-slate-800 bg-slate-950/70 p-0">
+      <div className="border-b border-slate-800 px-4 py-3">
+        <h2 className="text-lg font-medium text-slate-200">YAML Editor</h2>
+      </div>
+
+      <div className="h-[560px]">
+        <Editor
+          height="100%"
+          defaultLanguage="yaml"
+          value={yamlText}
+          onChange={onChange}
+          theme="vs-dark"
+          options={{
+            minimap: { enabled: false },
+            fontSize: 14,
+            tabSize: 2,
+            wordWrap: "on",
+            scrollBeyondLastLine: false,
+          }}
+        />
+      </div>
+    </Card>
+  )
+}

--- a/frontend/src/pages/ComposeEditor.jsx
+++ b/frontend/src/pages/ComposeEditor.jsx
@@ -1,19 +1,21 @@
 // src/pages/ComposeEditor.jsx
-
+// Compose Editor 페이지의 상태, 동기화, 배포 흐름을 관리합니다.
 import { useState } from "react"
-import Editor from "@monaco-editor/react"
 
 import MainLayout from "@/layouts/MainLayout"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
 import { deployComposeYaml } from "@/api/containerApi"
 import ComposeOptionForm from "@/features/compose/components/ComposeOptionForm"
+import ComposeEditorHeader from "@/features/compose/components/ComposeEditorHeader"
+import ComposeEditorToolbar from "@/features/compose/components/ComposeEditorToolbar"
+import ComposeFeedbackMessage from "@/features/compose/components/ComposeFeedbackMessage"
+import ComposeSyncControl from "@/features/compose/components/ComposeSyncControl"
+import ComposeYamlEditorPanel from "@/features/compose/components/ComposeYamlEditorPanel"
+import { Card } from "@/components/ui/card"
 import {
   convertOptionsToYaml,
   convertYamlToOptions,
 } from "@/features/compose/utils/composeYaml"
 
-// Compose Editor 옵션 UI의 초기 입력값을 정의합니다.
 const initialComposeOptions = {
   serviceName: "app",
   image: "nginx:latest",
@@ -24,12 +26,10 @@ const initialComposeOptions = {
   environmentValue: "production",
 }
 
-// YAML Editor의 초기 compose YAML 문자열을 정의합니다.
 const initialYamlText = `services:
   app:
     image: nginx:latest`
 
-// axios 또는 일반 Error 객체에서 화면에 표시할 에러 메시지를 추출합니다.
 function getErrorMessage(error) {
   return (
     error?.response?.data?.detail?.message ||
@@ -40,50 +40,65 @@ function getErrorMessage(error) {
 }
 
 export default function ComposeEditor() {
-  // 옵션 UI에서 관리하는 compose 입력 상태입니다.
   const [composeOptions, setComposeOptions] = useState(initialComposeOptions)
-
-  // Monaco Editor에서 관리하는 YAML 문자열 상태입니다.
   const [yamlText, setYamlText] = useState(initialYamlText)
-
-  // YAML 검증 또는 API 실패 메시지를 저장합니다.
+  const [lastEditedSource, setLastEditedSource] = useState("options")
   const [errorMessage, setErrorMessage] = useState("")
-
-  // Compose 배포 성공 메시지를 저장합니다.
   const [successMessage, setSuccessMessage] = useState("")
-
-  // Compose 배포 요청 중복 실행을 막기 위한 loading 상태입니다.
   const [isDeploying, setIsDeploying] = useState(false)
 
-  // 옵션 UI 값을 YAML 문자열로 변환합니다.
-  const handleOptionsToYaml = () => {
-    const nextYaml = convertOptionsToYaml(composeOptions)
+  const syncButtonLabel =
+    lastEditedSource === "options" ? "YAML에 반영" : "옵션에 반영"
 
-    setYamlText(nextYaml)
+  const resetMessages = () => {
     setErrorMessage("")
     setSuccessMessage("")
   }
 
-  // YAML 문자열을 옵션 UI 값으로 변환합니다.
+  const handleComposeOptionsChange = (nextOptions) => {
+    setComposeOptions(nextOptions)
+    setLastEditedSource("options")
+    resetMessages()
+  }
+
+  const handleYamlTextChange = (value) => {
+    setYamlText(value || "")
+    setLastEditedSource("yaml")
+    resetMessages()
+  }
+
+  const handleOptionsToYaml = () => {
+    const nextYaml = convertOptionsToYaml(composeOptions)
+
+    setYamlText(nextYaml)
+    resetMessages()
+  }
+
   const handleYamlToOptions = () => {
     try {
       const nextOptions = convertYamlToOptions(yamlText)
 
       setComposeOptions(nextOptions)
-      setErrorMessage("")
-      setSuccessMessage("")
+      resetMessages()
     } catch {
       setErrorMessage("YAML 문법 또는 지원하지 않는 Compose 구조입니다.")
       setSuccessMessage("")
     }
   }
 
-  // 현재 YAML을 검증한 뒤 백엔드 compose up API로 배포 요청을 보냅니다.
+  const handleSyncCompose = () => {
+    if (lastEditedSource === "options") {
+      handleOptionsToYaml()
+      return
+    }
+
+    handleYamlToOptions()
+  }
+
   const handleDeployCompose = async () => {
     try {
       setIsDeploying(true)
-      setErrorMessage("")
-      setSuccessMessage("")
+      resetMessages()
 
       convertYamlToOptions(yamlText)
 
@@ -102,48 +117,19 @@ export default function ComposeEditor() {
   return (
     <MainLayout>
       <div className="flex flex-col gap-6">
-        <div>
-          <h1 className="text-2xl font-semibold text-slate-100">
-            Compose Editor
-          </h1>
-          <p className="mt-1 text-sm text-slate-500">
-            Docker Compose YAML을 옵션 또는 코드로 작성하고 배포합니다.
-          </p>
-        </div>
+        <ComposeEditorHeader />
 
-        <div className="flex flex-wrap items-center gap-3">
-          <Button variant="outline" onClick={handleOptionsToYaml}>
-            옵션 → YAML
-          </Button>
+        <ComposeEditorToolbar
+          isDeploying={isDeploying}
+          onDeployCompose={handleDeployCompose}
+        />
 
-          <Button variant="outline" onClick={handleYamlToOptions}>
-            YAML → 옵션
-          </Button>
+        <ComposeFeedbackMessage
+          errorMessage={errorMessage}
+          successMessage={successMessage}
+        />
 
-          <Button onClick={handleDeployCompose} disabled={isDeploying}>
-            {isDeploying ? "배포 요청 중..." : "Compose 실행"}
-          </Button>
-
-          {isDeploying && (
-            <p className="text-sm text-slate-400">
-              백엔드로 Compose YAML을 전송하고 있습니다.
-            </p>
-          )}
-        </div>
-
-        {(errorMessage || successMessage) && (
-          <div className="rounded-2xl border border-slate-800 bg-slate-950/70 px-4 py-3">
-            {errorMessage && (
-              <p className="text-sm text-red-400">{errorMessage}</p>
-            )}
-
-            {successMessage && (
-              <p className="text-sm text-cyan-300">{successMessage}</p>
-            )}
-          </div>
-        )}
-
-        <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
           <Card className="border-slate-800 bg-slate-950/70 p-5">
             <div className="mb-5">
               <h2 className="text-lg font-medium text-slate-200">Options</h2>
@@ -154,38 +140,19 @@ export default function ComposeEditor() {
 
             <ComposeOptionForm
               options={composeOptions}
-              onChange={setComposeOptions}
+              onChange={handleComposeOptionsChange}
             />
           </Card>
 
-          <Card className="overflow-hidden border-slate-800 bg-slate-950/70 p-0">
-            <div className="border-b border-slate-800 px-4 py-3">
-              <h2 className="text-lg font-medium text-slate-200">
-                YAML Editor
-              </h2>
-            </div>
+          <ComposeSyncControl
+            label={syncButtonLabel}
+            onSync={handleSyncCompose}
+          />
 
-            <div className="h-[560px]">
-              <Editor
-                height="100%"
-                defaultLanguage="yaml"
-                value={yamlText}
-                onChange={(value) => {
-                  setYamlText(value || "")
-                  setErrorMessage("")
-                  setSuccessMessage("")
-                }}
-                theme="vs-dark"
-                options={{
-                  minimap: { enabled: false },
-                  fontSize: 14,
-                  tabSize: 2,
-                  wordWrap: "on",
-                  scrollBeyondLastLine: false,
-                }}
-              />
-            </div>
-          </Card>
+          <ComposeYamlEditorPanel
+            yamlText={yamlText}
+            onChange={handleYamlTextChange}
+          />
         </div>
       </div>
     </MainLayout>


### PR DESCRIPTION
## 연관 이슈
#85 

## 작업 내용
Compose Editor의 Options ↔ YAML 동기화 UX를 개선했습니다.
- 기존 양방향 변환 버튼을 단일 동기화 버튼으로 정리
- 마지막 수정 영역 기준으로 동기화 방향 결정
- 동기화 버튼을 Options와 YAML Editor 사이에 배치
- Compose Editor 화면을 Header / Toolbar / Feedback / Sync / YAML Editor 컴포넌트로 분리

## 참고 사항
- API 경로 및 요청 payload는 변경하지 않았습니다.
- ports 배열화, environment 배열화, optional attribute 지원은 후속 PR에서 진행 예정입니다.

<img width="1279" height="692" alt="syncux1" src="https://github.com/user-attachments/assets/fa21bffc-5142-4460-921e-1b8b39bab851" />

<img width="1279" height="692" alt="syncux2" src="https://github.com/user-attachments/assets/88d47615-a35e-49cf-8ed9-0a0f6c4a9224" />
