### PR TITLE
feat: Compose Editor ports/environment 배열 입력 지원

### DIFF
--- a/frontend/src/features/compose/components/ComposeArrayFieldGroup.jsx
+++ b/frontend/src/features/compose/components/ComposeArrayFieldGroup.jsx
@@ -1,0 +1,62 @@
+// 배열 기반 Compose 옵션 입력 섹션의 공통 레이아웃을 렌더링합니다.
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+
+export default function ComposeArrayFieldGroup({
+  title,
+  description,
+  addLabel,
+  emptyMessage,
+  items,
+  onAdd,
+  onRemove,
+  renderItem,
+}) {
+  const normalizedItems = Array.isArray(items) ? items : []
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-slate-800 bg-slate-950/40 p-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <Label>{title}</Label>
+
+          {description && (
+            <p className="mt-1 text-xs text-slate-500">{description}</p>
+          )}
+        </div>
+
+        <Button type="button" variant="outline" size="sm" onClick={onAdd}>
+          {addLabel}
+        </Button>
+      </div>
+
+      {normalizedItems.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-800 px-3 py-4 text-sm text-slate-500">
+          {emptyMessage}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {normalizedItems.map((item, index) => (
+            <div
+              key={`${title}-${index}`}
+              className="grid gap-3 rounded-xl border border-slate-800 bg-slate-950/60 p-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+            >
+              {renderItem(item, index)}
+
+              <div className="flex items-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full md:w-auto"
+                  onClick={() => onRemove(index)}
+                >
+                  삭제
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/compose/components/ComposeEnvironmentFields.jsx
+++ b/frontend/src/features/compose/components/ComposeEnvironmentFields.jsx
@@ -1,0 +1,83 @@
+// Compose service의 environment 배열 입력 UI를 렌더링합니다.
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import ComposeArrayFieldGroup from "@/features/compose/components/ComposeArrayFieldGroup"
+
+const emptyEnvironment = {
+  key: "",
+  value: "",
+}
+
+function normalizeEnvironment(environment) {
+  return Array.isArray(environment) ? environment : []
+}
+
+export default function ComposeEnvironmentFields({ environment, onChange }) {
+  const normalizedEnvironment = normalizeEnvironment(environment)
+
+  const updateEnvironment = (index, field, value) => {
+    const nextEnvironment = normalizedEnvironment.map(
+      (environmentItem, itemIndex) => {
+        if (itemIndex !== index) return environmentItem
+
+        return {
+          ...environmentItem,
+          [field]: value,
+        }
+      },
+    )
+
+    onChange(nextEnvironment)
+  }
+
+  const addEnvironment = () => {
+    onChange([...normalizedEnvironment, emptyEnvironment])
+  }
+
+  const removeEnvironment = (index) => {
+    const nextEnvironment = normalizedEnvironment.filter((_, itemIndex) => {
+      return itemIndex !== index
+    })
+
+    onChange(nextEnvironment)
+  }
+
+  return (
+    <ComposeArrayFieldGroup
+      title="Environment"
+      description="KEY=VALUE 문자열 배열 형태로 YAML에 반영합니다."
+      addLabel="환경변수 추가"
+      emptyMessage="추가된 environment 값이 없습니다."
+      items={normalizedEnvironment}
+      onAdd={addEnvironment}
+      onRemove={removeEnvironment}
+      renderItem={(environmentItem, index) => (
+        <>
+          <div className="grid gap-2">
+            <Label htmlFor={`environmentKey-${index}`}>Key</Label>
+            <Input
+              id={`environmentKey-${index}`}
+              value={environmentItem.key ?? ""}
+              onChange={(event) =>
+                updateEnvironment(index, "key", event.target.value)
+              }
+              placeholder="NODE_ENV"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor={`environmentValue-${index}`}>Value</Label>
+            <Input
+              id={`environmentValue-${index}`}
+              value={environmentItem.value ?? ""}
+              onChange={(event) =>
+                updateEnvironment(index, "value", event.target.value)
+              }
+              placeholder="production"
+            />
+          </div>
+        </>
+      )}
+    />
+  )
+}

--- a/frontend/src/features/compose/components/ComposeOptionForm.jsx
+++ b/frontend/src/features/compose/components/ComposeOptionForm.jsx
@@ -1,6 +1,21 @@
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import ComposePortFields from "@/features/compose/components/ComposePortFields"
+
+const sampleOptions = {
+  serviceName: "app",
+  image: "nginx:latest",
+  containerName: "my-container",
+  ports: [
+    {
+      hostPort: "8080",
+      containerPort: "80",
+    },
+  ],
+  environmentKey: "NODE_ENV",
+  environmentValue: "production",
+}
 
 export default function ComposeOptionForm({ options, onChange }) {
   const updateField = (field, value) => {
@@ -11,7 +26,7 @@ export default function ComposeOptionForm({ options, onChange }) {
   }
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-6">
       <div className="grid gap-2">
         <Label htmlFor="serviceName">Service Name</Label>
         <Input
@@ -42,25 +57,10 @@ export default function ComposeOptionForm({ options, onChange }) {
         />
       </div>
 
-      <div className="grid gap-2">
-        <Label htmlFor="hostPort">Host Port</Label>
-        <Input
-          id="hostPort"
-          value={options.hostPort}
-          onChange={(event) => updateField("hostPort", event.target.value)}
-          placeholder="8080"
-        />
-      </div>
-
-      <div className="grid gap-2">
-        <Label htmlFor="containerPort">Container Port</Label>
-        <Input
-          id="containerPort"
-          value={options.containerPort}
-          onChange={(event) => updateField("containerPort", event.target.value)}
-          placeholder="80"
-        />
-      </div>
+      <ComposePortFields
+        ports={options.ports}
+        onChange={(nextPorts) => updateField("ports", nextPorts)}
+      />
 
       <div className="grid gap-2">
         <Label htmlFor="environmentKey">Environment Key</Label>
@@ -90,17 +90,7 @@ export default function ComposeOptionForm({ options, onChange }) {
         type="button"
         variant="outline"
         className="w-full"
-        onClick={() =>
-          onChange({
-            serviceName: "app",
-            image: "nginx:latest",
-            containerName: "my-container",
-            hostPort: "8080",
-            containerPort: "80",
-            environmentKey: "NODE_ENV",
-            environmentValue: "production",
-          })
-        }
+        onClick={() => onChange(sampleOptions)}
       >
         샘플 값 채우기
       </Button>

--- a/frontend/src/features/compose/components/ComposeOptionForm.jsx
+++ b/frontend/src/features/compose/components/ComposeOptionForm.jsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import ComposePortFields from "@/features/compose/components/ComposePortFields"
+import ComposeEnvironmentFields from "@/features/compose/components/ComposeEnvironmentFields"
 
 const sampleOptions = {
   serviceName: "app",
@@ -13,8 +14,12 @@ const sampleOptions = {
       containerPort: "80",
     },
   ],
-  environmentKey: "NODE_ENV",
-  environmentValue: "production",
+  environment: [
+    {
+      key: "NODE_ENV",
+      value: "production",
+    },
+  ],
 }
 
 export default function ComposeOptionForm({ options, onChange }) {
@@ -62,29 +67,12 @@ export default function ComposeOptionForm({ options, onChange }) {
         onChange={(nextPorts) => updateField("ports", nextPorts)}
       />
 
-      <div className="grid gap-2">
-        <Label htmlFor="environmentKey">Environment Key</Label>
-        <Input
-          id="environmentKey"
-          value={options.environmentKey}
-          onChange={(event) =>
-            updateField("environmentKey", event.target.value)
-          }
-          placeholder="NODE_ENV"
-        />
-      </div>
-
-      <div className="grid gap-2">
-        <Label htmlFor="environmentValue">Environment Value</Label>
-        <Input
-          id="environmentValue"
-          value={options.environmentValue}
-          onChange={(event) =>
-            updateField("environmentValue", event.target.value)
-          }
-          placeholder="production"
-        />
-      </div>
+      <ComposeEnvironmentFields
+        environment={options.environment}
+        onChange={(nextEnvironment) =>
+          updateField("environment", nextEnvironment)
+        }
+      />
 
       <Button
         type="button"

--- a/frontend/src/features/compose/components/ComposePortFields.jsx
+++ b/frontend/src/features/compose/components/ComposePortFields.jsx
@@ -1,0 +1,81 @@
+// Compose service의 ports 배열 입력 UI를 렌더링합니다.
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import ComposeArrayFieldGroup from "@/features/compose/components/ComposeArrayFieldGroup"
+
+const emptyPort = {
+  hostPort: "",
+  containerPort: "",
+}
+
+function normalizePorts(ports) {
+  return Array.isArray(ports) ? ports : []
+}
+
+export default function ComposePortFields({ ports, onChange }) {
+  const normalizedPorts = normalizePorts(ports)
+
+  const updatePort = (index, field, value) => {
+    const nextPorts = normalizedPorts.map((port, portIndex) => {
+      if (portIndex !== index) return port
+
+      return {
+        ...port,
+        [field]: value,
+      }
+    })
+
+    onChange(nextPorts)
+  }
+
+  const addPort = () => {
+    onChange([...normalizedPorts, emptyPort])
+  }
+
+  const removePort = (index) => {
+    const nextPorts = normalizedPorts.filter((_, portIndex) => {
+      return portIndex !== index
+    })
+
+    onChange(nextPorts)
+  }
+
+  return (
+    <ComposeArrayFieldGroup
+      title="Ports"
+      description="short syntax 기준으로 host:container 형태를 지원합니다."
+      addLabel="포트 추가"
+      emptyMessage="추가된 port mapping이 없습니다."
+      items={normalizedPorts}
+      onAdd={addPort}
+      onRemove={removePort}
+      renderItem={(port, index) => (
+        <>
+          <div className="grid gap-2">
+            <Label htmlFor={`hostPort-${index}`}>Host Port</Label>
+            <Input
+              id={`hostPort-${index}`}
+              value={port.hostPort ?? ""}
+              onChange={(event) =>
+                updatePort(index, "hostPort", event.target.value)
+              }
+              placeholder="8080"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor={`containerPort-${index}`}>Container Port</Label>
+            <Input
+              id={`containerPort-${index}`}
+              value={port.containerPort ?? ""}
+              onChange={(event) =>
+                updatePort(index, "containerPort", event.target.value)
+              }
+              placeholder="80"
+            />
+          </div>
+        </>
+      )}
+    />
+  )
+}

--- a/frontend/src/features/compose/utils/composeEnvironmentUtils.js
+++ b/frontend/src/features/compose/utils/composeEnvironmentUtils.js
@@ -1,0 +1,76 @@
+// Compose environment 옵션의 YAML 변환 및 파싱을 처리합니다.
+function createValidationError(message) {
+  return new Error(message)
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function normalizeEnvironment(environment) {
+  return Array.isArray(environment) ? environment : []
+}
+
+function parseEnvironmentItem(environmentItem) {
+  if (typeof environmentItem !== "string") {
+    throw createValidationError(
+      "environment 배열은 KEY=VALUE 문자열 형식이어야 합니다.",
+    )
+  }
+
+  const equalIndex = environmentItem.indexOf("=")
+
+  if (equalIndex === -1) {
+    throw createValidationError(
+      "environment 배열은 KEY=VALUE 형식이어야 합니다.",
+    )
+  }
+
+  return {
+    key: environmentItem.slice(0, equalIndex).trim(),
+    value: environmentItem.slice(equalIndex + 1),
+  }
+}
+
+export function parseEnvironment(environment) {
+  if (!environment) {
+    return []
+  }
+
+  if (Array.isArray(environment)) {
+    return environment.map(parseEnvironmentItem).filter((environmentItem) => {
+      return environmentItem.key
+    })
+  }
+
+  if (isObject(environment)) {
+    return Object.entries(environment)
+      .map(([key, value]) => {
+        return {
+          key,
+          value: String(value ?? ""),
+        }
+      })
+      .filter((environmentItem) => {
+        return environmentItem.key
+      })
+  }
+
+  throw createValidationError(
+    "environment는 배열 또는 객체 형식이어야 합니다.",
+  )
+}
+
+export function buildEnvironmentValues(environment) {
+  return normalizeEnvironment(environment)
+    .map((environmentItem) => {
+      const key = environmentItem.key?.trim() ?? ""
+
+      if (!key) {
+        return null
+      }
+
+      return `${key}=${environmentItem.value ?? ""}`
+    })
+    .filter(Boolean)
+}

--- a/frontend/src/features/compose/utils/composePortUtils.js
+++ b/frontend/src/features/compose/utils/composePortUtils.js
@@ -1,0 +1,77 @@
+// Compose ports 옵션의 YAML 변환 및 파싱을 처리합니다.
+function createValidationError(message) {
+  return new Error(message)
+}
+
+function createEmptyPort() {
+  return {
+    hostPort: "",
+    containerPort: "",
+  }
+}
+
+function normalizePorts(ports) {
+  return Array.isArray(ports) ? ports : []
+}
+
+function parsePort(portValue) {
+  if (typeof portValue !== "string" && typeof portValue !== "number") {
+    throw createValidationError("ports는 문자열 또는 숫자 형식이어야 합니다.")
+  }
+
+  const portText = String(portValue).trim()
+
+  if (!portText) {
+    return createEmptyPort()
+  }
+
+  if (portText.includes("/")) {
+    throw createValidationError(
+      "ports protocol 형식은 아직 지원하지 않습니다.",
+    )
+  }
+
+  const portParts = portText.split(":")
+
+  if (portParts.length > 2) {
+    throw createValidationError(
+      "ports는 host:container short syntax만 지원합니다.",
+    )
+  }
+
+  const [hostPort = "", containerPort = ""] = portParts
+
+  return {
+    hostPort: hostPort.trim(),
+    containerPort: (containerPort || hostPort).trim(),
+  }
+}
+
+export function parsePorts(ports) {
+  if (!ports) {
+    return []
+  }
+
+  if (!Array.isArray(ports)) {
+    throw createValidationError("ports는 배열 형식이어야 합니다.")
+  }
+
+  return ports.map(parsePort).filter((port) => {
+    return port.hostPort || port.containerPort
+  })
+}
+
+export function buildPortValues(ports) {
+  return normalizePorts(ports)
+    .map((port) => {
+      const hostPort = port.hostPort?.trim() ?? ""
+      const containerPort = port.containerPort?.trim() ?? ""
+
+      if (!hostPort || !containerPort) {
+        return null
+      }
+
+      return `${hostPort}:${containerPort}`
+    })
+    .filter(Boolean)
+}

--- a/frontend/src/features/compose/utils/composeYaml.js
+++ b/frontend/src/features/compose/utils/composeYaml.js
@@ -1,6 +1,10 @@
 import yaml from "js-yaml"
 
 import {
+  buildEnvironmentValues,
+  parseEnvironment,
+} from "@/features/compose/utils/composeEnvironmentUtils"
+import {
   buildPortValues,
   parsePorts,
 } from "@/features/compose/utils/composePortUtils"
@@ -13,65 +17,6 @@ function createValidationError(message) {
 
 function isObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value)
-}
-
-function parseEnvironment(environment) {
-  if (!environment) {
-    return {
-      environmentKey: "",
-      environmentValue: "",
-    }
-  }
-
-  if (Array.isArray(environment)) {
-    const firstEnvironment = environment[0]
-
-    if (!firstEnvironment) {
-      return {
-        environmentKey: "",
-        environmentValue: "",
-      }
-    }
-
-    if (typeof firstEnvironment !== "string") {
-      throw createValidationError(
-        "environment 배열은 KEY=VALUE 문자열 형식이어야 합니다.",
-      )
-    }
-
-    const equalIndex = firstEnvironment.indexOf("=")
-
-    if (equalIndex === -1) {
-      throw createValidationError(
-        "environment 배열은 KEY=VALUE 형식이어야 합니다.",
-      )
-    }
-
-    return {
-      environmentKey: firstEnvironment.slice(0, equalIndex),
-      environmentValue: firstEnvironment.slice(equalIndex + 1),
-    }
-  }
-
-  if (isObject(environment)) {
-    const firstKey = Object.keys(environment)[0]
-
-    if (!firstKey) {
-      return {
-        environmentKey: "",
-        environmentValue: "",
-      }
-    }
-
-    return {
-      environmentKey: firstKey,
-      environmentValue: String(environment[firstKey] ?? ""),
-    }
-  }
-
-  throw createValidationError(
-    "environment는 배열 또는 객체 형식이어야 합니다.",
-  )
 }
 
 export function convertOptionsToYaml(options) {
@@ -97,10 +42,10 @@ export function convertOptionsToYaml(options) {
     service.ports = portValues
   }
 
-  if (options.environmentKey?.trim() && options.environmentValue?.trim()) {
-    service.environment = [
-      `${options.environmentKey.trim()}=${options.environmentValue.trim()}`,
-    ]
+  const environmentValues = buildEnvironmentValues(options.environment)
+
+  if (environmentValues.length > 0) {
+    service.environment = environmentValues
   }
 
   return yaml.dump(composeObject, {
@@ -137,16 +82,13 @@ export function convertYamlToOptions(yamlText) {
   }
 
   const ports = parsePorts(service.ports)
-  const { environmentKey, environmentValue } = parseEnvironment(
-    service.environment,
-  )
+  const environment = parseEnvironment(service.environment)
 
   return {
     serviceName,
     image: service.image,
     containerName: service.container_name || "",
     ports,
-    environmentKey,
-    environmentValue,
+    environment,
   }
 }

--- a/frontend/src/features/compose/utils/composeYaml.js
+++ b/frontend/src/features/compose/utils/composeYaml.js
@@ -1,5 +1,10 @@
 import yaml from "js-yaml"
 
+import {
+  buildPortValues,
+  parsePorts,
+} from "@/features/compose/utils/composePortUtils"
+
 const DEFAULT_SERVICE_NAME = "app"
 
 function createValidationError(message) {
@@ -8,20 +13,6 @@ function createValidationError(message) {
 
 function isObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value)
-}
-
-function parsePort(portValue) {
-  if (typeof portValue !== "string" && typeof portValue !== "number") {
-    throw createValidationError("ports는 문자열 또는 숫자 형식이어야 합니다.")
-  }
-
-  const portText = String(portValue)
-  const [hostPort = "", containerPort = ""] = portText.split(":")
-
-  return {
-    hostPort,
-    containerPort: containerPort || hostPort,
-  }
 }
 
 function parseEnvironment(environment) {
@@ -100,8 +91,10 @@ export function convertOptionsToYaml(options) {
     service.container_name = options.containerName.trim()
   }
 
-  if (options.hostPort?.trim() && options.containerPort?.trim()) {
-    service.ports = [`${options.hostPort.trim()}:${options.containerPort.trim()}`]
+  const portValues = buildPortValues(options.ports)
+
+  if (portValues.length > 0) {
+    service.ports = portValues
   }
 
   if (options.environmentKey?.trim() && options.environmentValue?.trim()) {
@@ -143,21 +136,7 @@ export function convertYamlToOptions(yamlText) {
     throw createValidationError("service에는 image 문자열이 필요합니다.")
   }
 
-  let hostPort = ""
-  let containerPort = ""
-
-  if (service.ports) {
-    if (!Array.isArray(service.ports)) {
-      throw createValidationError("ports는 배열 형식이어야 합니다.")
-    }
-
-    if (service.ports.length > 0) {
-      const parsedPort = parsePort(service.ports[0])
-      hostPort = parsedPort.hostPort
-      containerPort = parsedPort.containerPort
-    }
-  }
-
+  const ports = parsePorts(service.ports)
   const { environmentKey, environmentValue } = parseEnvironment(
     service.environment,
   )
@@ -166,8 +145,7 @@ export function convertYamlToOptions(yamlText) {
     serviceName,
     image: service.image,
     containerName: service.container_name || "",
-    hostPort,
-    containerPort,
+    ports,
     environmentKey,
     environmentValue,
   }

--- a/frontend/src/pages/ComposeEditor.jsx
+++ b/frontend/src/pages/ComposeEditor.jsx
@@ -26,8 +26,12 @@ const initialComposeOptions = {
       containerPort: "80",
     },
   ],
-  environmentKey: "NODE_ENV",
-  environmentValue: "production",
+  environment: [
+    {
+      key: "NODE_ENV",
+      value: "production",
+    },
+  ],
 }
 
 const initialYamlText = `services:

--- a/frontend/src/pages/ComposeEditor.jsx
+++ b/frontend/src/pages/ComposeEditor.jsx
@@ -20,8 +20,12 @@ const initialComposeOptions = {
   serviceName: "app",
   image: "nginx:latest",
   containerName: "my-container",
-  hostPort: "8080",
-  containerPort: "80",
+  ports: [
+    {
+      hostPort: "8080",
+      containerPort: "80",
+    },
+  ],
   environmentKey: "NODE_ENV",
   environmentValue: "production",
 }


### PR DESCRIPTION
## 연관 이슈
#87 

## 작업 내용
- Compose Editor에서 ports와 environment를 배열 기반으로 입력할 수 있도록 개선했습니다.


## 스크린샷
Options에서 port와 environment 추가 후 YAML 반영
<img width="769" height="656" alt="option-yaml" src="https://github.com/user-attachments/assets/70b4ede5-5608-4359-842e-b97ebb1fc5ea" />

YAML에서 port와 environment 삭제 후 Options 반영
<img width="758" height="553" alt="yaml-option" src="https://github.com/user-attachments/assets/a4572aef-bfa3-4a18-8d5e-e2060a656fca" />



