### PR TITLE
feat: Compose Editor Options 기반 YAML 생성 구조 개선

### DIFF
--- a/frontend/src/features/compose/components/ComposeDynamicField.jsx
+++ b/frontend/src/features/compose/components/ComposeDynamicField.jsx
@@ -1,0 +1,211 @@
+// Compose 확장 필드 정의에 따라 입력 UI를 렌더링합니다.
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function normalizeList(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function normalizeObject(value) {
+  return isPlainObject(value) ? value : {}
+}
+
+export default function ComposeDynamicField({
+  idPrefix = "compose",
+  field,
+  value,
+  onChange,
+}) {
+  const fieldId = `${idPrefix}-${field.key}`
+
+  if (field.type === "select") {
+    return (
+      <div className="grid gap-2">
+        <Label htmlFor={fieldId}>{field.label}</Label>
+        <select
+          id={fieldId}
+          value={value ?? ""}
+          onChange={(event) => onChange(event.target.value)}
+          className="h-10 rounded-md border border-slate-700 bg-slate-950 px-3 text-sm text-slate-100 outline-none focus:border-slate-500"
+        >
+          {field.options?.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+
+        {field.description && (
+          <p className="text-xs text-slate-500">{field.description}</p>
+        )}
+      </div>
+    )
+  }
+
+  if (field.type === "boolean") {
+    return (
+      <label
+        htmlFor={fieldId}
+        className="flex cursor-pointer items-start gap-3 rounded-xl border border-slate-800 bg-slate-950/60 p-3"
+      >
+        <input
+          id={fieldId}
+          type="checkbox"
+          checked={value === true}
+          onChange={(event) => onChange(event.target.checked)}
+          className="mt-1 size-4 rounded border-slate-600 bg-slate-950"
+        />
+
+        <span>
+          <span className="block text-sm font-medium text-slate-200">
+            {field.label}
+          </span>
+
+          {field.description && (
+            <span className="mt-1 block text-xs text-slate-500">
+              {field.description}
+            </span>
+          )}
+        </span>
+      </label>
+    )
+  }
+
+  if (field.type === "list") {
+    const listValue = normalizeList(value)
+
+    const updateItem = (index, nextValue) => {
+      const nextList = listValue.map((item, itemIndex) => {
+        if (itemIndex !== index) return item
+        return nextValue
+      })
+
+      onChange(nextList)
+    }
+
+    const addItem = () => {
+      onChange([...listValue, ""])
+    }
+
+    const removeItem = (index) => {
+      const nextList = listValue.filter((_, itemIndex) => {
+        return itemIndex !== index
+      })
+
+      onChange(nextList)
+    }
+
+    return (
+      <div className="space-y-3 rounded-xl border border-slate-800 bg-slate-950/60 p-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <Label>{field.label}</Label>
+
+            {field.description && (
+              <p className="mt-1 text-xs text-slate-500">
+                {field.description}
+              </p>
+            )}
+          </div>
+
+          <Button type="button" variant="outline" size="sm" onClick={addItem}>
+            항목 추가
+          </Button>
+        </div>
+
+        {listValue.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-slate-800 px-3 py-3 text-sm text-slate-500">
+            추가된 값이 없습니다.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {listValue.map((item, index) => (
+              <div
+                key={`${fieldId}-${index}`}
+                className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]"
+              >
+                <Input
+                  value={item ?? ""}
+                  onChange={(event) => updateItem(index, event.target.value)}
+                  placeholder={field.placeholder}
+                />
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => removeItem(index)}
+                >
+                  삭제
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  if (field.type === "object") {
+    const objectValue = normalizeObject(value)
+
+    const updateObjectField = (objectField, nextValue) => {
+      onChange({
+        ...objectValue,
+        [objectField.key]: nextValue,
+      })
+    }
+
+    return (
+      <div className="space-y-3 rounded-xl border border-slate-800 bg-slate-950/60 p-3">
+        <div>
+          <Label>{field.label}</Label>
+
+          {field.description && (
+            <p className="mt-1 text-xs text-slate-500">{field.description}</p>
+          )}
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          {field.fields?.map((objectField) => (
+            <div key={objectField.key} className="grid gap-2">
+              <Label htmlFor={`${fieldId}-${objectField.key}`}>
+                {objectField.label}
+              </Label>
+
+              <Input
+                id={`${fieldId}-${objectField.key}`}
+                value={objectValue[objectField.key] ?? ""}
+                onChange={(event) =>
+                  updateObjectField(objectField, event.target.value)
+                }
+                placeholder={objectField.placeholder}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={fieldId}>{field.label}</Label>
+
+      <Input
+        id={fieldId}
+        value={value ?? ""}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={field.placeholder}
+      />
+
+      {field.description && (
+        <p className="text-xs text-slate-500">{field.description}</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/compose/components/ComposeEnvironmentFields.jsx
+++ b/frontend/src/features/compose/components/ComposeEnvironmentFields.jsx
@@ -12,7 +12,11 @@ function normalizeEnvironment(environment) {
   return Array.isArray(environment) ? environment : []
 }
 
-export default function ComposeEnvironmentFields({ environment, onChange }) {
+export default function ComposeEnvironmentFields({
+  idPrefix = "compose",
+  environment,
+  onChange,
+}) {
   const normalizedEnvironment = normalizeEnvironment(environment)
 
   const updateEnvironment = (index, field, value) => {
@@ -54,9 +58,9 @@ export default function ComposeEnvironmentFields({ environment, onChange }) {
       renderItem={(environmentItem, index) => (
         <>
           <div className="grid gap-2">
-            <Label htmlFor={`environmentKey-${index}`}>Key</Label>
+            <Label htmlFor={`${idPrefix}-environmentKey-${index}`}>Key</Label>
             <Input
-              id={`environmentKey-${index}`}
+              id={`${idPrefix}-environmentKey-${index}`}
               value={environmentItem.key ?? ""}
               onChange={(event) =>
                 updateEnvironment(index, "key", event.target.value)
@@ -66,9 +70,11 @@ export default function ComposeEnvironmentFields({ environment, onChange }) {
           </div>
 
           <div className="grid gap-2">
-            <Label htmlFor={`environmentValue-${index}`}>Value</Label>
+            <Label htmlFor={`${idPrefix}-environmentValue-${index}`}>
+              Value
+            </Label>
             <Input
-              id={`environmentValue-${index}`}
+              id={`${idPrefix}-environmentValue-${index}`}
               value={environmentItem.value ?? ""}
               onChange={(event) =>
                 updateEnvironment(index, "value", event.target.value)

--- a/frontend/src/features/compose/components/ComposeOptionForm.jsx
+++ b/frontend/src/features/compose/components/ComposeOptionForm.jsx
@@ -98,9 +98,6 @@ export default function ComposeOptionForm({ options, onChange }) {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h3 className="text-sm font-medium text-slate-200">Services</h3>
-          <p className="mt-1 text-xs text-slate-500">
-            Compose YAML의 services 하위에 생성할 service들을 관리합니다.
-          </p>
         </div>
 
         <Button type="button" variant="outline" onClick={addService}>

--- a/frontend/src/features/compose/components/ComposeOptionForm.jsx
+++ b/frontend/src/features/compose/components/ComposeOptionForm.jsx
@@ -1,78 +1,125 @@
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import ComposePortFields from "@/features/compose/components/ComposePortFields"
-import ComposeEnvironmentFields from "@/features/compose/components/ComposeEnvironmentFields"
+import ComposeServiceFields from "@/features/compose/components/ComposeServiceFields"
 
 const sampleOptions = {
-  serviceName: "app",
-  image: "nginx:latest",
-  containerName: "my-container",
-  ports: [
+  services: [
     {
-      hostPort: "8080",
-      containerPort: "80",
+      id: "service-1",
+      serviceName: "frontend",
+      image: "node:20-alpine",
+      containerName: "frontend-container",
+      ports: [
+        {
+          hostPort: "5173",
+          containerPort: "5173",
+        },
+      ],
+      environment: [
+        {
+          key: "VITE_API_URL",
+          value: "http://localhost:8000",
+        },
+      ],
     },
-  ],
-  environment: [
     {
-      key: "NODE_ENV",
-      value: "production",
+      id: "service-2",
+      serviceName: "backend",
+      image: "python:3.12-slim",
+      containerName: "backend-container",
+      ports: [
+        {
+          hostPort: "8000",
+          containerPort: "8000",
+        },
+      ],
+      environment: [
+        {
+          key: "PYTHONPATH",
+          value: "/backend",
+        },
+      ],
     },
   ],
 }
 
+function createEmptyService(index) {
+  return {
+    id: `service-${Date.now()}-${index}`,
+    serviceName: `service-${index}`,
+    image: "",
+    containerName: "",
+    ports: [],
+    environment: [],
+  }
+}
+
+function normalizeServices(services) {
+  return Array.isArray(services) ? services : []
+}
+
 export default function ComposeOptionForm({ options, onChange }) {
-  const updateField = (field, value) => {
+  const services = normalizeServices(options.services)
+
+  const updateServices = (nextServices) => {
     onChange({
       ...options,
-      [field]: value,
+      services: nextServices,
     })
   }
 
+  const updateService = (index, nextService) => {
+    const nextServices = services.map((service, serviceIndex) => {
+      if (serviceIndex !== index) return service
+
+      return nextService
+    })
+
+    updateServices(nextServices)
+  }
+
+  const addService = () => {
+    updateServices([...services, createEmptyService(services.length + 1)])
+  }
+
+  const removeService = (index) => {
+    if (services.length <= 1) {
+      return
+    }
+
+    const nextServices = services.filter((_, serviceIndex) => {
+      return serviceIndex !== index
+    })
+
+    updateServices(nextServices)
+  }
+
   return (
-    <div className="space-y-6">
-      <div className="grid gap-2">
-        <Label htmlFor="serviceName">Service Name</Label>
-        <Input
-          id="serviceName"
-          value={options.serviceName}
-          onChange={(event) => updateField("serviceName", event.target.value)}
-          placeholder="app"
-        />
+    <div className="space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-sm font-medium text-slate-200">Services</h3>
+          <p className="mt-1 text-xs text-slate-500">
+            Compose YAML의 services 하위에 생성할 service들을 관리합니다.
+          </p>
+        </div>
+
+        <Button type="button" variant="outline" onClick={addService}>
+          서비스 추가
+        </Button>
       </div>
 
-      <div className="grid gap-2">
-        <Label htmlFor="image">Image</Label>
-        <Input
-          id="image"
-          value={options.image}
-          onChange={(event) => updateField("image", event.target.value)}
-          placeholder="nginx:latest"
-        />
+      <div className="space-y-4">
+        {services.map((service, index) => (
+          <ComposeServiceFields
+            key={service.id || `service-${index}`}
+            service={service}
+            serviceIndex={index}
+            canRemove={services.length > 1}
+            onChange={(nextService) => updateService(index, nextService)}
+            onRemove={() => removeService(index)}
+          />
+        ))}
       </div>
-
-      <div className="grid gap-2">
-        <Label htmlFor="containerName">Container Name</Label>
-        <Input
-          id="containerName"
-          value={options.containerName}
-          onChange={(event) => updateField("containerName", event.target.value)}
-          placeholder="my-container"
-        />
-      </div>
-
-      <ComposePortFields
-        ports={options.ports}
-        onChange={(nextPorts) => updateField("ports", nextPorts)}
-      />
-
-      <ComposeEnvironmentFields
-        environment={options.environment}
-        onChange={(nextEnvironment) =>
-          updateField("environment", nextEnvironment)
-        }
-      />
 
       <Button
         type="button"

--- a/frontend/src/features/compose/components/ComposeOptionalFieldSection.jsx
+++ b/frontend/src/features/compose/components/ComposeOptionalFieldSection.jsx
@@ -1,0 +1,104 @@
+// Compose 확장 필드를 카테고리별 토글 섹션으로 렌더링합니다.
+import { useState } from "react"
+import { ChevronDown } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import ComposeDynamicField from "@/features/compose/components/ComposeDynamicField"
+import { COMPOSE_FIELD_CATEGORIES } from "@/features/compose/constants/composeFieldCategories"
+import { getComposeFieldsByCategory } from "@/features/compose/constants/composeServiceFields"
+
+function getFieldValue(optionalFields, fieldKey) {
+  return optionalFields?.[fieldKey]
+}
+
+export default function ComposeOptionalFieldSection({
+  idPrefix = "compose",
+  optionalFields = {},
+  onChange,
+}) {
+  const [openCategoryIds, setOpenCategoryIds] = useState([])
+
+  const toggleCategory = (categoryId) => {
+    setOpenCategoryIds((currentCategoryIds) => {
+      if (currentCategoryIds.includes(categoryId)) {
+        return currentCategoryIds.filter((currentCategoryId) => {
+          return currentCategoryId !== categoryId
+        })
+      }
+
+      return [...currentCategoryIds, categoryId]
+    })
+  }
+
+  const updateOptionalField = (fieldKey, value) => {
+    onChange({
+      ...optionalFields,
+      [fieldKey]: value,
+    })
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="border-t border-slate-800 pt-5">
+        <h4 className="text-sm font-medium text-slate-200">확장 필드</h4>
+        <p className="mt-1 text-xs text-slate-500">
+          추가 service attribute는 카테고리별로 열어서 입력할 수 있습니다.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {COMPOSE_FIELD_CATEGORIES.map((category) => {
+          const fields = getComposeFieldsByCategory(category.id)
+          const isOpen = openCategoryIds.includes(category.id)
+
+          if (fields.length === 0) {
+            return null
+          }
+
+          return (
+            <div
+              key={category.id}
+              className="rounded-2xl border border-slate-800 bg-slate-950/40"
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                className="flex h-auto w-full items-center justify-between px-4 py-3 text-left hover:bg-slate-900"
+                onClick={() => toggleCategory(category.id)}
+              >
+                <span>
+                  <span className="block text-sm font-medium text-slate-200">
+                    {category.title}
+                  </span>
+                  <span className="mt-1 block text-xs font-normal text-slate-500">
+                    {category.description}
+                  </span>
+                </span>
+
+                <ChevronDown
+                  className={`size-4 shrink-0 text-slate-500 transition-transform ${
+                    isOpen ? "rotate-180" : ""
+                  }`}
+                />
+              </Button>
+
+              {isOpen && (
+                <div className="space-y-4 border-t border-slate-800 px-4 py-4">
+                  {fields.map((field) => (
+                    <ComposeDynamicField
+                      key={field.key}
+                      idPrefix={`${idPrefix}-${category.id}`}
+                      field={field}
+                      value={getFieldValue(optionalFields, field.key)}
+                      onChange={(value) => updateOptionalField(field.key, value)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/compose/components/ComposeOptionalFieldSection.jsx
+++ b/frontend/src/features/compose/components/ComposeOptionalFieldSection.jsx
@@ -41,9 +41,6 @@ export default function ComposeOptionalFieldSection({
     <div className="space-y-3">
       <div className="border-t border-slate-800 pt-5">
         <h4 className="text-sm font-medium text-slate-200">확장 필드</h4>
-        <p className="mt-1 text-xs text-slate-500">
-          추가 service attribute는 카테고리별로 열어서 입력할 수 있습니다.
-        </p>
       </div>
 
       <div className="space-y-3">

--- a/frontend/src/features/compose/components/ComposePortFields.jsx
+++ b/frontend/src/features/compose/components/ComposePortFields.jsx
@@ -12,7 +12,7 @@ function normalizePorts(ports) {
   return Array.isArray(ports) ? ports : []
 }
 
-export default function ComposePortFields({ ports, onChange }) {
+export default function ComposePortFields({ idPrefix = "compose", ports, onChange }) {
   const normalizedPorts = normalizePorts(ports)
 
   const updatePort = (index, field, value) => {
@@ -52,9 +52,9 @@ export default function ComposePortFields({ ports, onChange }) {
       renderItem={(port, index) => (
         <>
           <div className="grid gap-2">
-            <Label htmlFor={`hostPort-${index}`}>Host Port</Label>
+            <Label htmlFor={`${idPrefix}-hostPort-${index}`}>Host Port</Label>
             <Input
-              id={`hostPort-${index}`}
+              id={`${idPrefix}-hostPort-${index}`}
               value={port.hostPort ?? ""}
               onChange={(event) =>
                 updatePort(index, "hostPort", event.target.value)
@@ -64,9 +64,11 @@ export default function ComposePortFields({ ports, onChange }) {
           </div>
 
           <div className="grid gap-2">
-            <Label htmlFor={`containerPort-${index}`}>Container Port</Label>
+            <Label htmlFor={`${idPrefix}-containerPort-${index}`}>
+              Container Port
+            </Label>
             <Input
-              id={`containerPort-${index}`}
+              id={`${idPrefix}-containerPort-${index}`}
               value={port.containerPort ?? ""}
               onChange={(event) =>
                 updatePort(index, "containerPort", event.target.value)

--- a/frontend/src/features/compose/components/ComposeServiceFields.jsx
+++ b/frontend/src/features/compose/components/ComposeServiceFields.jsx
@@ -1,9 +1,10 @@
-// Compose service 하나의 기본 입력 필드를 렌더링합니다.
+// Compose service 하나의 기본 입력 필드와 확장 필드 섹션을 렌더링합니다.
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import ComposePortFields from "@/features/compose/components/ComposePortFields"
 import ComposeEnvironmentFields from "@/features/compose/components/ComposeEnvironmentFields"
+import ComposeOptionalFieldSection from "@/features/compose/components/ComposeOptionalFieldSection"
+import ComposePortFields from "@/features/compose/components/ComposePortFields"
 
 export default function ComposeServiceFields({
   service,
@@ -90,6 +91,14 @@ export default function ComposeServiceFields({
         environment={service.environment}
         onChange={(nextEnvironment) =>
           updateField("environment", nextEnvironment)
+        }
+      />
+
+      <ComposeOptionalFieldSection
+        idPrefix={idPrefix}
+        optionalFields={service.optionalFields}
+        onChange={(nextOptionalFields) =>
+          updateField("optionalFields", nextOptionalFields)
         }
       />
     </div>

--- a/frontend/src/features/compose/components/ComposeServiceFields.jsx
+++ b/frontend/src/features/compose/components/ComposeServiceFields.jsx
@@ -1,0 +1,97 @@
+// Compose service 하나의 기본 입력 필드를 렌더링합니다.
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import ComposePortFields from "@/features/compose/components/ComposePortFields"
+import ComposeEnvironmentFields from "@/features/compose/components/ComposeEnvironmentFields"
+
+export default function ComposeServiceFields({
+  service,
+  serviceIndex,
+  canRemove,
+  onChange,
+  onRemove,
+}) {
+  const updateField = (field, value) => {
+    onChange({
+      ...service,
+      [field]: value,
+    })
+  }
+
+  const serviceLabel = service.serviceName?.trim() || `service-${serviceIndex + 1}`
+  const idPrefix = `service-${service.id || serviceIndex}`
+
+  return (
+    <div className="space-y-5 rounded-2xl border border-slate-800 bg-slate-950/50 p-4">
+      <div className="flex flex-col gap-3 border-b border-slate-800 pb-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-slate-100">
+            {serviceLabel}
+          </h3>
+          <p className="mt-1 text-xs text-slate-500">
+            services.{serviceLabel} 하위에 생성될 설정입니다.
+          </p>
+        </div>
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!canRemove}
+          onClick={onRemove}
+        >
+          서비스 삭제
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-2">
+          <Label htmlFor={`${idPrefix}-serviceName`}>Service Name</Label>
+          <Input
+            id={`${idPrefix}-serviceName`}
+            value={service.serviceName ?? ""}
+            onChange={(event) => updateField("serviceName", event.target.value)}
+            placeholder="app"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor={`${idPrefix}-image`}>Image</Label>
+          <Input
+            id={`${idPrefix}-image`}
+            value={service.image ?? ""}
+            onChange={(event) => updateField("image", event.target.value)}
+            placeholder="nginx:latest"
+          />
+        </div>
+
+        <div className="grid gap-2 md:col-span-2">
+          <Label htmlFor={`${idPrefix}-containerName`}>Container Name</Label>
+          <Input
+            id={`${idPrefix}-containerName`}
+            value={service.containerName ?? ""}
+            onChange={(event) =>
+              updateField("containerName", event.target.value)
+            }
+            placeholder="my-container"
+          />
+        </div>
+      </div>
+
+      <ComposePortFields
+        idPrefix={idPrefix}
+        ports={service.ports}
+        onChange={(nextPorts) => updateField("ports", nextPorts)}
+      />
+
+      <ComposeEnvironmentFields
+        idPrefix={idPrefix}
+        environment={service.environment}
+        onChange={(nextEnvironment) =>
+          updateField("environment", nextEnvironment)
+        }
+      />
+    </div>
+  )
+}

--- a/frontend/src/features/compose/components/ComposeSyncControl.jsx
+++ b/frontend/src/features/compose/components/ComposeSyncControl.jsx
@@ -1,20 +1,20 @@
-// Options와 YAML Editor 사이의 수동 동기화 버튼을 렌더링합니다.
-import { Repeat2 } from "lucide-react"
+// Options 입력값을 YAML Editor에 반영하는 생성 버튼을 렌더링합니다.
+import { FileCode2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 
-export default function ComposeSyncControl({ label, onSync }) {
+export default function ComposeSyncControl({ onGenerateYaml }) {
   return (
     <div className="flex items-center justify-center">
       <div className="flex w-full items-center justify-center rounded-2xl border border-slate-800 bg-slate-950/70 p-3 xl:w-auto">
         <Button
           type="button"
           variant="outline"
-          onClick={onSync}
+          onClick={onGenerateYaml}
           className="w-full border-slate-700 bg-slate-950 text-base font-semibold text-slate-200 hover:bg-slate-800 hover:text-slate-50 xl:w-auto"
         >
-          <Repeat2 className="mr-2 size-5" />
-          {label}
+          <FileCode2 className="mr-2 size-5" />
+          YAML 생성
         </Button>
       </div>
     </div>

--- a/frontend/src/features/compose/components/ComposeSyncControl.jsx
+++ b/frontend/src/features/compose/components/ComposeSyncControl.jsx
@@ -14,7 +14,7 @@ export default function ComposeSyncControl({ onGenerateYaml }) {
           className="w-full border-slate-700 bg-slate-950 text-base font-semibold text-slate-200 hover:bg-slate-800 hover:text-slate-50 xl:w-auto"
         >
           <FileCode2 className="mr-2 size-5" />
-          YAML 생성
+          YAML 변환
         </Button>
       </div>
     </div>

--- a/frontend/src/features/compose/components/ComposeYamlEditorPanel.jsx
+++ b/frontend/src/features/compose/components/ComposeYamlEditorPanel.jsx
@@ -5,12 +5,12 @@ import { Card } from "@/components/ui/card"
 
 export default function ComposeYamlEditorPanel({ yamlText, onChange }) {
   return (
-    <Card className="overflow-hidden border-slate-800 bg-slate-950/70 p-0">
+    <Card className="flex h-full min-h-[560px] flex-col overflow-hidden border-slate-800 bg-slate-950/70 p-0">
       <div className="border-b border-slate-800 px-4 py-3">
         <h2 className="text-lg font-medium text-slate-200">YAML Editor</h2>
       </div>
 
-      <div className="h-[560px]">
+      <div className="min-h-[560px] flex-1">
         <Editor
           height="100%"
           defaultLanguage="yaml"

--- a/frontend/src/features/compose/constants/composeFieldCategories.js
+++ b/frontend/src/features/compose/constants/composeFieldCategories.js
@@ -1,0 +1,43 @@
+// Compose 확장 필드 카테고리와 표시 순서를 정의합니다.
+export const COMPOSE_FIELD_CATEGORIES = [
+  {
+    id: "execution",
+    title: "실행 설정",
+    description: "컨테이너 실행 명령과 작업 디렉터리 관련 옵션입니다.",
+  },
+  {
+    id: "lifecycle",
+    title: "컨테이너 동작 설정",
+    description: "재시작 정책, 터미널, 읽기 전용 실행 등 동작 관련 옵션입니다.",
+  },
+  {
+    id: "build",
+    title: "빌드 설정",
+    description: "이미지 빌드에 필요한 기본 경로 설정입니다.",
+  },
+  {
+    id: "network",
+    title: "네트워크 설정",
+    description: "호스트명과 네트워크 노출 관련 옵션입니다.",
+  },
+  {
+    id: "storage",
+    title: "스토리지/파일 설정",
+    description: "임시 파일 시스템과 마운트 관련 옵션입니다.",
+  },
+  {
+    id: "resource",
+    title: "리소스 설정",
+    description: "CPU, 메모리 등 컨테이너 리소스 제한 관련 옵션입니다.",
+  },
+  {
+    id: "security",
+    title: "보안/권한 설정",
+    description: "권한, capability, 격리 수준 관련 옵션입니다.",
+  },
+  {
+    id: "operation",
+    title: "서비스 관계/운영/배포 설정",
+    description: "프로필, 의존 관계, 운영 설정 관련 옵션입니다.",
+  },
+]

--- a/frontend/src/features/compose/constants/composeServiceFields.js
+++ b/frontend/src/features/compose/constants/composeServiceFields.js
@@ -1,0 +1,95 @@
+// Compose service 확장 필드 정의를 관리합니다.
+// 후속 작업에서는 이 목록에 field definition을 추가하는 방식으로 확장합니다.
+export const COMPOSE_SERVICE_FIELD_DEFINITIONS = [
+  {
+    key: "command",
+    yamlKey: "command",
+    label: "Command",
+    description: "컨테이너 시작 시 실행할 명령입니다.",
+    category: "execution",
+    type: "text",
+    placeholder: "npm run dev",
+  },
+  {
+    key: "restart",
+    yamlKey: "restart",
+    label: "Restart Policy",
+    description: "컨테이너 종료 시 재시작 정책입니다.",
+    category: "lifecycle",
+    type: "select",
+    options: [
+      { label: "선택 안 함", value: "" },
+      { label: "no", value: "no" },
+      { label: "always", value: "always" },
+      { label: "on-failure", value: "on-failure" },
+      { label: "unless-stopped", value: "unless-stopped" },
+    ],
+  },
+  {
+    key: "build",
+    yamlKey: "build",
+    label: "Build",
+    description: "이미지를 빌드할 기본 context 경로입니다.",
+    category: "build",
+    type: "object",
+    fields: [
+      {
+        key: "context",
+        yamlKey: "context",
+        label: "Context",
+        type: "text",
+        placeholder: "./frontend",
+      },
+    ],
+  },
+  {
+    key: "hostname",
+    yamlKey: "hostname",
+    label: "Hostname",
+    description: "컨테이너 내부에서 사용할 hostname입니다.",
+    category: "network",
+    type: "text",
+    placeholder: "frontend-host",
+  },
+  {
+    key: "tmpfs",
+    yamlKey: "tmpfs",
+    label: "Tmpfs",
+    description: "tmpfs로 마운트할 경로 목록입니다.",
+    category: "storage",
+    type: "list",
+    placeholder: "/tmp",
+  },
+  {
+    key: "cpus",
+    yamlKey: "cpus",
+    label: "CPUs",
+    description: "컨테이너가 사용할 CPU 제한 값입니다.",
+    category: "resource",
+    type: "text",
+    placeholder: "0.5",
+  },
+  {
+    key: "privileged",
+    yamlKey: "privileged",
+    label: "Privileged",
+    description: "컨테이너를 privileged 모드로 실행합니다.",
+    category: "security",
+    type: "boolean",
+  },
+  {
+    key: "profiles",
+    yamlKey: "profiles",
+    label: "Profiles",
+    description: "Compose profile 이름 목록입니다.",
+    category: "operation",
+    type: "list",
+    placeholder: "dev",
+  },
+]
+
+export function getComposeFieldsByCategory(categoryId) {
+  return COMPOSE_SERVICE_FIELD_DEFINITIONS.filter((field) => {
+    return field.category === categoryId
+  })
+}

--- a/frontend/src/features/compose/utils/composeFieldValueBuilder.js
+++ b/frontend/src/features/compose/utils/composeFieldValueBuilder.js
@@ -1,0 +1,88 @@
+// field definition 기반 확장 필드 값을 YAML에 넣을 수 있는 값으로 변환합니다.
+// 필드별 의존성 검증은 수행하지 않고, 빈 값 제외와 단순 타입 변환만 처리합니다.
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function normalizeList(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function isEmptyFieldValue(value) {
+  if (value === undefined || value === null || value === "") {
+    return true
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0
+  }
+
+  if (isPlainObject(value)) {
+    return Object.keys(value).length === 0
+  }
+
+  return false
+}
+
+function buildTextValue(value) {
+  if (typeof value !== "string") {
+    return isEmptyFieldValue(value) ? null : value
+  }
+
+  const trimmedValue = value.trim()
+
+  return trimmedValue ? trimmedValue : null
+}
+
+function buildBooleanValue(value) {
+  return value === true ? true : null
+}
+
+function buildListValue(value) {
+  const listValue = normalizeList(value)
+    .map((item) => {
+      return typeof item === "string" ? item.trim() : item
+    })
+    .filter((item) => {
+      return !isEmptyFieldValue(item)
+    })
+
+  return listValue.length > 0 ? listValue : null
+}
+
+function buildObjectValue(field, value) {
+  if (!isPlainObject(value)) {
+    return null
+  }
+
+  const result = {}
+
+  field.fields?.forEach((objectField) => {
+    const objectFieldValue = value[objectField.key]
+    const nextValue = buildTextValue(objectFieldValue)
+
+    if (nextValue === null) {
+      return
+    }
+
+    result[objectField.yamlKey] = nextValue
+  })
+
+  return Object.keys(result).length > 0 ? result : null
+}
+
+export function buildComposeFieldValue(field, value) {
+  if (field.type === "boolean") {
+    return buildBooleanValue(value)
+  }
+
+  if (field.type === "list") {
+    return buildListValue(value)
+  }
+
+  if (field.type === "object") {
+    return buildObjectValue(field, value)
+  }
+
+  return buildTextValue(value)
+}

--- a/frontend/src/features/compose/utils/composeServiceYamlBuilder.js
+++ b/frontend/src/features/compose/utils/composeServiceYamlBuilder.js
@@ -1,0 +1,91 @@
+// Compose Options의 services 배열을 YAML 생성을 위한 services 객체로 변환합니다.
+import { COMPOSE_SERVICE_FIELD_DEFINITIONS } from "@/features/compose/constants/composeServiceFields"
+import { buildEnvironmentValues } from "@/features/compose/utils/composeEnvironmentUtils"
+import { buildComposeFieldValue } from "@/features/compose/utils/composeFieldValueBuilder"
+import { buildPortValues } from "@/features/compose/utils/composePortUtils"
+
+const DEFAULT_SERVICE_NAME = "app"
+
+function normalizeServices(services) {
+  return Array.isArray(services) ? services : []
+}
+
+function createServiceName(rawServiceName, index, usedServiceNames) {
+  const fallbackName =
+    index === 0 ? DEFAULT_SERVICE_NAME : `${DEFAULT_SERVICE_NAME}-${index + 1}`
+
+  const baseName = rawServiceName?.trim() || fallbackName
+  let serviceName = baseName
+  let duplicateIndex = 2
+
+  while (usedServiceNames.has(serviceName)) {
+    serviceName = `${baseName}-${duplicateIndex}`
+    duplicateIndex += 1
+  }
+
+  usedServiceNames.add(serviceName)
+
+  return serviceName
+}
+
+function applyOptionalFields(serviceYaml, optionalFields = {}) {
+  COMPOSE_SERVICE_FIELD_DEFINITIONS.forEach((field) => {
+    const fieldValue = buildComposeFieldValue(field, optionalFields[field.key])
+
+    if (fieldValue === null) {
+      return
+    }
+
+    serviceYaml[field.yamlKey] = fieldValue
+  })
+}
+
+function buildServiceObject(serviceOptions) {
+  const serviceYaml = {}
+
+  if (serviceOptions.image?.trim()) {
+    serviceYaml.image = serviceOptions.image.trim()
+  }
+
+  if (serviceOptions.containerName?.trim()) {
+    serviceYaml.container_name = serviceOptions.containerName.trim()
+  }
+
+  applyOptionalFields(serviceYaml, serviceOptions.optionalFields)
+
+  const portValues = buildPortValues(serviceOptions.ports)
+
+  if (portValues.length > 0) {
+    serviceYaml.ports = portValues
+  }
+
+  const environmentValues = buildEnvironmentValues(serviceOptions.environment)
+
+  if (environmentValues.length > 0) {
+    serviceYaml.environment = environmentValues
+  }
+
+  return serviceYaml
+}
+
+export function buildServicesObject(services) {
+  const normalizedServices = normalizeServices(services)
+  const usedServiceNames = new Set()
+  const servicesYaml = {}
+
+  normalizedServices.forEach((serviceOptions, index) => {
+    const serviceName = createServiceName(
+      serviceOptions.serviceName,
+      index,
+      usedServiceNames,
+    )
+
+    servicesYaml[serviceName] = buildServiceObject(serviceOptions)
+  })
+
+  if (Object.keys(servicesYaml).length === 0) {
+    servicesYaml[DEFAULT_SERVICE_NAME] = {}
+  }
+
+  return servicesYaml
+}

--- a/frontend/src/features/compose/utils/composeYaml.js
+++ b/frontend/src/features/compose/utils/composeYaml.js
@@ -1,9 +1,6 @@
 import yaml from "js-yaml"
 
-import { buildEnvironmentValues } from "@/features/compose/utils/composeEnvironmentUtils"
-import { buildPortValues } from "@/features/compose/utils/composePortUtils"
-
-const DEFAULT_SERVICE_NAME = "app"
+import { buildServicesObject } from "@/features/compose/utils/composeServiceYamlBuilder"
 
 function createValidationError(message) {
   return new Error(message)
@@ -11,54 +8,6 @@ function createValidationError(message) {
 
 function isObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value)
-}
-
-function normalizeServices(services) {
-  return Array.isArray(services) ? services : []
-}
-
-function createServiceName(rawServiceName, index, usedServiceNames) {
-  const fallbackName =
-    index === 0 ? DEFAULT_SERVICE_NAME : `${DEFAULT_SERVICE_NAME}-${index + 1}`
-
-  const baseName = rawServiceName?.trim() || fallbackName
-  let serviceName = baseName
-  let duplicateIndex = 2
-
-  while (usedServiceNames.has(serviceName)) {
-    serviceName = `${baseName}-${duplicateIndex}`
-    duplicateIndex += 1
-  }
-
-  usedServiceNames.add(serviceName)
-
-  return serviceName
-}
-
-function buildServiceObject(serviceOptions) {
-  const service = {}
-
-  if (serviceOptions.image?.trim()) {
-    service.image = serviceOptions.image.trim()
-  }
-
-  if (serviceOptions.containerName?.trim()) {
-    service.container_name = serviceOptions.containerName.trim()
-  }
-
-  const portValues = buildPortValues(serviceOptions.ports)
-
-  if (portValues.length > 0) {
-    service.ports = portValues
-  }
-
-  const environmentValues = buildEnvironmentValues(serviceOptions.environment)
-
-  if (environmentValues.length > 0) {
-    service.environment = environmentValues
-  }
-
-  return service
 }
 
 export function validateYamlSyntax(yamlText) {
@@ -76,25 +25,8 @@ export function validateYamlSyntax(yamlText) {
 }
 
 export function convertOptionsToYaml(options) {
-  const services = normalizeServices(options.services)
-  const usedServiceNames = new Set()
-
   const composeObject = {
-    services: {},
-  }
-
-  services.forEach((serviceOptions, index) => {
-    const serviceName = createServiceName(
-      serviceOptions.serviceName,
-      index,
-      usedServiceNames,
-    )
-
-    composeObject.services[serviceName] = buildServiceObject(serviceOptions)
-  })
-
-  if (Object.keys(composeObject.services).length === 0) {
-    composeObject.services[DEFAULT_SERVICE_NAME] = {}
+    services: buildServicesObject(options.services),
   }
 
   return yaml.dump(composeObject, {

--- a/frontend/src/features/compose/utils/composeYaml.js
+++ b/frontend/src/features/compose/utils/composeYaml.js
@@ -1,13 +1,7 @@
 import yaml from "js-yaml"
 
-import {
-  buildEnvironmentValues,
-  parseEnvironment,
-} from "@/features/compose/utils/composeEnvironmentUtils"
-import {
-  buildPortValues,
-  parsePorts,
-} from "@/features/compose/utils/composePortUtils"
+import { buildEnvironmentValues } from "@/features/compose/utils/composeEnvironmentUtils"
+import { buildPortValues } from "@/features/compose/utils/composePortUtils"
 
 const DEFAULT_SERVICE_NAME = "app"
 
@@ -19,18 +13,34 @@ function isObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value)
 }
 
+export function validateYamlSyntax(yamlText) {
+  const parsed = yaml.load(yamlText)
+
+  if (!isObject(parsed)) {
+    throw createValidationError("YAML 최상위 구조는 객체여야 합니다.")
+  }
+
+  if (!isObject(parsed.services)) {
+    throw createValidationError("services 필드가 필요합니다.")
+  }
+
+  return parsed
+}
+
 export function convertOptionsToYaml(options) {
   const serviceName = options.serviceName?.trim() || DEFAULT_SERVICE_NAME
 
   const composeObject = {
     services: {
-      [serviceName]: {
-        image: options.image?.trim() || "",
-      },
+      [serviceName]: {},
     },
   }
 
   const service = composeObject.services[serviceName]
+
+  if (options.image?.trim()) {
+    service.image = options.image.trim()
+  }
 
   if (options.containerName?.trim()) {
     service.container_name = options.containerName.trim()
@@ -52,43 +62,4 @@ export function convertOptionsToYaml(options) {
     noRefs: true,
     lineWidth: -1,
   })
-}
-
-export function convertYamlToOptions(yamlText) {
-  const parsed = yaml.load(yamlText)
-
-  if (!isObject(parsed)) {
-    throw createValidationError("YAML 최상위 구조는 객체여야 합니다.")
-  }
-
-  if (!isObject(parsed.services)) {
-    throw createValidationError("services 필드가 필요합니다.")
-  }
-
-  const serviceName = Object.keys(parsed.services)[0]
-
-  if (!serviceName) {
-    throw createValidationError("최소 1개의 service가 필요합니다.")
-  }
-
-  const service = parsed.services[serviceName]
-
-  if (!isObject(service)) {
-    throw createValidationError("service 설정은 객체 형식이어야 합니다.")
-  }
-
-  if (!service.image || typeof service.image !== "string") {
-    throw createValidationError("service에는 image 문자열이 필요합니다.")
-  }
-
-  const ports = parsePorts(service.ports)
-  const environment = parseEnvironment(service.environment)
-
-  return {
-    serviceName,
-    image: service.image,
-    containerName: service.container_name || "",
-    ports,
-    environment,
-  }
 }

--- a/frontend/src/features/compose/utils/composeYaml.js
+++ b/frontend/src/features/compose/utils/composeYaml.js
@@ -13,6 +13,54 @@ function isObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value)
 }
 
+function normalizeServices(services) {
+  return Array.isArray(services) ? services : []
+}
+
+function createServiceName(rawServiceName, index, usedServiceNames) {
+  const fallbackName =
+    index === 0 ? DEFAULT_SERVICE_NAME : `${DEFAULT_SERVICE_NAME}-${index + 1}`
+
+  const baseName = rawServiceName?.trim() || fallbackName
+  let serviceName = baseName
+  let duplicateIndex = 2
+
+  while (usedServiceNames.has(serviceName)) {
+    serviceName = `${baseName}-${duplicateIndex}`
+    duplicateIndex += 1
+  }
+
+  usedServiceNames.add(serviceName)
+
+  return serviceName
+}
+
+function buildServiceObject(serviceOptions) {
+  const service = {}
+
+  if (serviceOptions.image?.trim()) {
+    service.image = serviceOptions.image.trim()
+  }
+
+  if (serviceOptions.containerName?.trim()) {
+    service.container_name = serviceOptions.containerName.trim()
+  }
+
+  const portValues = buildPortValues(serviceOptions.ports)
+
+  if (portValues.length > 0) {
+    service.ports = portValues
+  }
+
+  const environmentValues = buildEnvironmentValues(serviceOptions.environment)
+
+  if (environmentValues.length > 0) {
+    service.environment = environmentValues
+  }
+
+  return service
+}
+
 export function validateYamlSyntax(yamlText) {
   const parsed = yaml.load(yamlText)
 
@@ -28,34 +76,25 @@ export function validateYamlSyntax(yamlText) {
 }
 
 export function convertOptionsToYaml(options) {
-  const serviceName = options.serviceName?.trim() || DEFAULT_SERVICE_NAME
+  const services = normalizeServices(options.services)
+  const usedServiceNames = new Set()
 
   const composeObject = {
-    services: {
-      [serviceName]: {},
-    },
+    services: {},
   }
 
-  const service = composeObject.services[serviceName]
+  services.forEach((serviceOptions, index) => {
+    const serviceName = createServiceName(
+      serviceOptions.serviceName,
+      index,
+      usedServiceNames,
+    )
 
-  if (options.image?.trim()) {
-    service.image = options.image.trim()
-  }
+    composeObject.services[serviceName] = buildServiceObject(serviceOptions)
+  })
 
-  if (options.containerName?.trim()) {
-    service.container_name = options.containerName.trim()
-  }
-
-  const portValues = buildPortValues(options.ports)
-
-  if (portValues.length > 0) {
-    service.ports = portValues
-  }
-
-  const environmentValues = buildEnvironmentValues(options.environment)
-
-  if (environmentValues.length > 0) {
-    service.environment = environmentValues
+  if (Object.keys(composeObject.services).length === 0) {
+    composeObject.services[DEFAULT_SERVICE_NAME] = {}
   }
 
   return yaml.dump(composeObject, {

--- a/frontend/src/pages/ComposeEditor.jsx
+++ b/frontend/src/pages/ComposeEditor.jsx
@@ -122,10 +122,6 @@ export default function ComposeEditor() {
           <Card className="border-slate-800 bg-slate-950/70 p-5">
             <div className="mb-5">
               <h2 className="text-lg font-medium text-slate-200">Options</h2>
-              <p className="mt-1 text-sm text-slate-500">
-                여러 service의 Options 입력값을 기준으로 Docker Compose
-                YAML을 생성합니다.
-              </p>
             </div>
 
             <ComposeOptionForm

--- a/frontend/src/pages/ComposeEditor.jsx
+++ b/frontend/src/pages/ComposeEditor.jsx
@@ -1,5 +1,5 @@
 // src/pages/ComposeEditor.jsx
-// Compose Editor 페이지의 상태, 동기화, 배포 흐름을 관리합니다.
+// Compose Editor 페이지의 상태, YAML 생성, 배포 흐름을 관리합니다.
 import { useState } from "react"
 
 import MainLayout from "@/layouts/MainLayout"
@@ -13,7 +13,7 @@ import ComposeYamlEditorPanel from "@/features/compose/components/ComposeYamlEdi
 import { Card } from "@/components/ui/card"
 import {
   convertOptionsToYaml,
-  convertYamlToOptions,
+  validateYamlSyntax,
 } from "@/features/compose/utils/composeYaml"
 
 const initialComposeOptions = {
@@ -34,9 +34,7 @@ const initialComposeOptions = {
   ],
 }
 
-const initialYamlText = `services:
-  app:
-    image: nginx:latest`
+const initialYamlText = convertOptionsToYaml(initialComposeOptions)
 
 function getErrorMessage(error) {
   return (
@@ -50,13 +48,9 @@ function getErrorMessage(error) {
 export default function ComposeEditor() {
   const [composeOptions, setComposeOptions] = useState(initialComposeOptions)
   const [yamlText, setYamlText] = useState(initialYamlText)
-  const [lastEditedSource, setLastEditedSource] = useState("options")
   const [errorMessage, setErrorMessage] = useState("")
   const [successMessage, setSuccessMessage] = useState("")
   const [isDeploying, setIsDeploying] = useState(false)
-
-  const syncButtonLabel =
-    lastEditedSource === "options" ? "YAML에 반영" : "옵션에 반영"
 
   const resetMessages = () => {
     setErrorMessage("")
@@ -65,42 +59,24 @@ export default function ComposeEditor() {
 
   const handleComposeOptionsChange = (nextOptions) => {
     setComposeOptions(nextOptions)
-    setLastEditedSource("options")
     resetMessages()
   }
 
   const handleYamlTextChange = (value) => {
     setYamlText(value || "")
-    setLastEditedSource("yaml")
     resetMessages()
   }
 
-  const handleOptionsToYaml = () => {
-    const nextYaml = convertOptionsToYaml(composeOptions)
-
-    setYamlText(nextYaml)
-    resetMessages()
-  }
-
-  const handleYamlToOptions = () => {
+  const handleGenerateYaml = () => {
     try {
-      const nextOptions = convertYamlToOptions(yamlText)
+      const nextYaml = convertOptionsToYaml(composeOptions)
 
-      setComposeOptions(nextOptions)
+      setYamlText(nextYaml)
       resetMessages()
     } catch {
-      setErrorMessage("YAML 문법 또는 지원하지 않는 Compose 구조입니다.")
+      setErrorMessage("Options 값을 YAML로 변환하는 중 오류가 발생했습니다.")
       setSuccessMessage("")
     }
-  }
-
-  const handleSyncCompose = () => {
-    if (lastEditedSource === "options") {
-      handleOptionsToYaml()
-      return
-    }
-
-    handleYamlToOptions()
   }
 
   const handleDeployCompose = async () => {
@@ -108,7 +84,7 @@ export default function ComposeEditor() {
       setIsDeploying(true)
       resetMessages()
 
-      convertYamlToOptions(yamlText)
+      validateYamlSyntax(yamlText)
 
       const result = await deployComposeYaml(yamlText)
 
@@ -142,7 +118,7 @@ export default function ComposeEditor() {
             <div className="mb-5">
               <h2 className="text-lg font-medium text-slate-200">Options</h2>
               <p className="mt-1 text-sm text-slate-500">
-                MVP 단계에서는 단일 service 기준 필드만 지원합니다.
+                Options 입력값을 기준으로 Docker Compose YAML을 생성합니다.
               </p>
             </div>
 
@@ -152,10 +128,7 @@ export default function ComposeEditor() {
             />
           </Card>
 
-          <ComposeSyncControl
-            label={syncButtonLabel}
-            onSync={handleSyncCompose}
-          />
+          <ComposeSyncControl onGenerateYaml={handleGenerateYaml} />
 
           <ComposeYamlEditorPanel
             yamlText={yamlText}

--- a/frontend/src/pages/ComposeEditor.jsx
+++ b/frontend/src/pages/ComposeEditor.jsx
@@ -118,7 +118,7 @@ export default function ComposeEditor() {
           successMessage={successMessage}
         />
 
-        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
+        <div className="grid grid-cols-1 items-stretch gap-6 xl:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
           <Card className="border-slate-800 bg-slate-950/70 p-5">
             <div className="mb-5">
               <h2 className="text-lg font-medium text-slate-200">Options</h2>

--- a/frontend/src/pages/ComposeEditor.jsx
+++ b/frontend/src/pages/ComposeEditor.jsx
@@ -17,19 +17,24 @@ import {
 } from "@/features/compose/utils/composeYaml"
 
 const initialComposeOptions = {
-  serviceName: "app",
-  image: "nginx:latest",
-  containerName: "my-container",
-  ports: [
+  services: [
     {
-      hostPort: "8080",
-      containerPort: "80",
-    },
-  ],
-  environment: [
-    {
-      key: "NODE_ENV",
-      value: "production",
+      id: "service-1",
+      serviceName: "app",
+      image: "nginx:latest",
+      containerName: "my-container",
+      ports: [
+        {
+          hostPort: "8080",
+          containerPort: "80",
+        },
+      ],
+      environment: [
+        {
+          key: "NODE_ENV",
+          value: "production",
+        },
+      ],
     },
   ],
 }
@@ -118,7 +123,8 @@ export default function ComposeEditor() {
             <div className="mb-5">
               <h2 className="text-lg font-medium text-slate-200">Options</h2>
               <p className="mt-1 text-sm text-slate-500">
-                Options 입력값을 기준으로 Docker Compose YAML을 생성합니다.
+                여러 service의 Options 입력값을 기준으로 Docker Compose
+                YAML을 생성합니다.
               </p>
             </div>
 


### PR DESCRIPTION
## 연관 이슈
#91 

## 작업 내용
Compose Editor를 Options 기반 YAML 생성 구조로 변경하고, 다중 service 및 확장 필드 추가 기반을 정리했습니다.
확장 필드는 서비스 단위로 지원됩니다.

- Options → YAML 단방향 생성 구조로 변경
- services 배열 기반 다중 service 입력 지원
- service 추가/삭제 UI 추가
- 확장 필드 카테고리/토글 구조 추가
- 카테고리별 대표 필드 추가
  - 실행 설정: command
  - 컨테이너 동작 설정: restart
  - 빌드 설정: build.context
  - 네트워크 설정: hostname
  - 스토리지/파일 설정: tmpfs
  - 리소스 설정: cpus
  - 보안/권한 설정: privileged
  - 서비스 관계/운영/배포 설정: profiles
- 입력값이 없는 필드는 YAML 생성 결과에서 제외
- YAML 생성 로직을 builder 유틸로 분리
- 백엔드 API payload는 변경하지 않았습니다.

입력한 Options 기반 필드 확인
<img width="760" height="605" alt="1" src="https://github.com/user-attachments/assets/d0f4156c-c357-493a-bdcc-5902ee200830" />

확장 항목 제공
<img width="289" height="385" alt="확장필드" src="https://github.com/user-attachments/assets/b5d04bf4-5d79-4f43-9304-163e7367a378" />

토글 세부 내용 예시
<img width="284" height="482" alt="확장1" src="https://github.com/user-attachments/assets/23a6a13c-70fb-45ee-8c10-6d410f324a97" />
<img width="304" height="446" alt="확장2" src="https://github.com/user-attachments/assets/db301a30-3887-484b-9630-8b9c2237ee00" />

